### PR TITLE
Factoring out configs and definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .DS_Store
+*.DS_Store

--- a/PlatformIO ESP32 code/OSSM_ESP32/src/OSSM_Config.h
+++ b/PlatformIO ESP32 code/OSSM_ESP32/src/OSSM_Config.h
@@ -1,0 +1,48 @@
+/*
+    User Config for OSSM - Reference board users should tweak this to match their personal build.
+*/
+
+/*
+        Motion System Config
+*/
+//Top linear speed of the device.
+const float maxSpeedMmPerSecond = 1000.0f;
+//This should match the step/rev of your stepper or servo.
+//N.b. the iHSV57 has a table on the side for setting the DIP switches to your preference.
+const float motorStepPerRevolution = 800.0f;
+//Number of teeth the pulley that is attached to the servo/stepper shaft has.
+const float pulleyToothCount = 20.0f;
+// Set to your belt pitch (Distance between two teeth on the belt) (E.g. GT2 belt has 2mm tooth pitch)
+const float beltPitchMm = 2.0f;
+// This is in millimeters, and is what's used to define how much of
+// your rail is usable.
+// The absolute max your OSSM would have is the distance between the belt attachments subtract
+// the linear block holder length (75mm on OSSM)
+// Recommended to also subtract e.g. 20mm to keep the backstop well away from the device.
+const float maxStrokeLengthMm = 130.0f;
+/*
+        Web Config
+*/
+// This should be unique to your device. You will use this on the
+// web portal to interact with your OSSM.
+// there is NO security other than knowing this name, make this unique to avoid
+// collisions with other users
+const char *ossmId = "OSSM1";
+
+/*
+        Advanced Config
+*/
+// After homing this is the physical buffer distance from the effective zero to the home switch
+// This is to stop the home switch being smacked constantly
+const float strokeZeroOffsetmm = 6.0f;
+// The minimum value of the pot in percent
+// prevents noisy pots registering commands when turned down to zero by user
+const float commandDeadzonePercentage = 1.0f;
+// affects acceleration in stepper trajectory (Aggressiveness of motion)
+const float accelerationScaling = 80.0f;
+
+
+
+
+
+

--- a/PlatformIO ESP32 code/OSSM_ESP32/src/OSSM_PinDef.h
+++ b/PlatformIO ESP32 code/OSSM_ESP32/src/OSSM_PinDef.h
@@ -1,0 +1,49 @@
+
+/*
+    Pin Definitions - Drivers, Buttons and Remotes
+    OSSM Reference board users are unlikely to need to modify this! See OSSM_Config.h
+*/
+
+/*
+        Driver pins
+*/
+// Pin that pulses on servo/stepper steps - likely labelled PUL on drivers.
+#define MOTOR_STEP_PIN 14
+// Pin connected to driver/servo step direction - likely labelled DIR on drivers.
+// N.b. to iHSV57 users - DIP switch #5 can be flipped to invert motor direction entirely
+#define MOTOR_DIRECTION_PIN 27
+// Pin for motor enable - likely labelled ENA on drivers.
+#define MOTOR_ENABLE_PIN 26
+
+/*
+    Homing and safety pins
+*/
+// define the IO pin the emergency stop switch is connected to
+#define STOP_PIN 19
+// define the IO pin where the limit(homing) switch(es) are connected to (switches in
+// series in normally closed setup)
+#define LIMIT_SWITCH_PIN 12
+
+/*
+        Wifi Control Pins
+*/
+// Pin for WiFi reset button (optional)
+#define WIFI_RESET_PIN 0
+
+//Pin for the toggle for wifi control (Can be left alone if no hardware toggle is required)
+#define WIFI_CONTROL_TOGGLE_PIN 22
+
+#define LOCAL_CONTROLLER INPUT_PULLDOWN
+#define WIFI_CONTROLLER INPUT_PULLUP
+//Choose whether the default control scheme is local (e.g. OSSM remote, potentiometers, etc.) or through Wi-Fi
+//If both are desired, a hardware toggle will need to be installed and wired to WIFI_CONTROL_TOGGLE_PIN
+#define WIFI_CONTROL_DEFAULT LOCAL_CONTROLLER
+
+/*These are configured for the OSSM Remote - which has a screen, a potentiometer and an encoder which clicks*/
+#define SPEED_POT_PIN 34
+#define ENCODER_SWITCH 35
+#define ENCODER_A 18
+#define ENCODER_B 5
+#define REMOTE_SDA 21
+#define REMOTE_CLK 19
+#define REMOTE_ADDRESS 0x3c


### PR DESCRIPTION
Suggestion to move the user config out to its own file along with clarifications where possible as to what the configurations mean- further cleanup to come - such as moving the main file into non-test and splitting the functionalities such that it will be easier to work with later. As a note acceleration scaling cfg val (set to 80) is not intuitive at all - I couldn't really figure out what it meant even glancing at where it's used.