### PR TITLE
Reduce stroke engine max acceleration to 10000

### DIFF
--- a/PlatformIO ESP32 code/OSSM_ESP32/src/Stroke_Engine_Helper.h
+++ b/PlatformIO ESP32 code/OSSM_ESP32/src/Stroke_Engine_Helper.h
@@ -22,7 +22,7 @@
 
 static motorProperties servoMotor{
     .maxSpeed = 60 * (hardcode_maxSpeedMmPerSecond / (hardcode_pulleyToothCount * hardcode_beltPitchMm)),
-    .maxAcceleration = 100000,
+    .maxAcceleration = 10000,
     .stepsPerMillimeter = hardcode_motorStepPerRevolution / (hardcode_pulleyToothCount * hardcode_beltPitchMm),
     .invertDirection = true,
     .enableActiveLow = true,


### PR DESCRIPTION
This fixes the Jack Hammer & Nibbler pattern not working. See: https://github.com/theelims/StrokeEngine/issues/5

This reduced acceleration value also matches the value [behavior of the M5 remote](https://github.com/ortlof/OSSM-Stroke/blob/f7289a6f9023e28cd25acef3f44a2abee0be148c/src/OSSM_Config.h#L25) and the [Stroke Engine readme](https://github.com/theelims/StrokeEngine#initialize)