### PR TITLE
added force settings, made logging better, made internet more controlable, other small changes

### DIFF
--- a/PlatformIO ESP32 code/OSSM_ESP32/.clang-format
+++ b/PlatformIO ESP32 code/OSSM_ESP32/.clang-format
@@ -7,4 +7,5 @@ Language: Cpp
 BreakBeforeBraces: Allman
 SpacesBeforeTrailingComments: 1
 AllowShortFunctionsOnASingleLine: Empty
+IndentPPDirectives: BeforeHash
 ---

--- a/PlatformIO ESP32 code/OSSM_ESP32/.vscode/settings.json
+++ b/PlatformIO ESP32 code/OSSM_ESP32/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "files.associations": {
+        "array": "cpp",
+        "deque": "cpp",
+        "list": "cpp",
+        "string": "cpp",
+        "unordered_map": "cpp",
+        "unordered_set": "cpp",
+        "vector": "cpp",
+        "initializer_list": "cpp",
+        "regex": "cpp"
+    }
+}

--- a/PlatformIO ESP32 code/OSSM_ESP32/lib/StrokeEngine/src/StrokeEngine.cpp
+++ b/PlatformIO ESP32 code/OSSM_ESP32/lib/StrokeEngine/src/StrokeEngine.cpp
@@ -1,12 +1,13 @@
 #include <Arduino.h>
-#include <StrokeEngine.h>
 #include <FastAccelStepper.h>
+#include <StrokeEngine.h>
 #include <pattern.h>
 
 FastAccelStepperEngine engine = FastAccelStepperEngine();
 FastAccelStepper *servo = NULL;
 
-void StrokeEngine::begin(machineGeometry *physics, motorProperties *motor) {
+void StrokeEngine::begin(machineGeometry *physics, motorProperties *motor)
+{
     // store the machine geometry and motor properties pointer
     _physics = physics;
     _motor = motor;
@@ -33,7 +34,8 @@ void StrokeEngine::begin(machineGeometry *physics, motorProperties *motor) {
     // Setup FastAccelStepper
     engine.init();
     servo = engine.stepperConnectToPin(_motor->stepPin);
-    if (servo) {
+    if (servo)
+    {
         servo->setDirectionPin(_motor->directionPin, _motor->invertDirection);
         servo->setEnablePin(_motor->enablePin, _motor->enableActiveLow);
         servo->setAutoEnable(false);
@@ -41,33 +43,34 @@ void StrokeEngine::begin(machineGeometry *physics, motorProperties *motor) {
     }
     Serial.println("Servo initialized");
 
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
     Serial.println("Stroke Engine State: " + verboseState[_state]);
 #endif
 }
 
-void StrokeEngine::setSpeed(float speed, bool applyNow = false) {
-
+void StrokeEngine::setSpeed(float speed, bool applyNow = false)
+{
     // Update pattern with new speed, will be used with the next stroke or on update request
-    if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE) {
-
+    if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE)
+    {
         // Convert FPM into seconds to complete a full stroke
         // Constrain stroke time between 10ms and 120 seconds
         _timeOfStroke = constrain(60.0 / speed, 0.01, 120.0);
 
         patternTable[_patternIndex]->setTimeOfStroke(_timeOfStroke);
 
-#ifdef DEBUG_TALKATIVE
-    Serial.println("setTimeOfStroke: " + String(_timeOfStroke, 2));
+#if DEBUG_STROKE_ENGINE
+        Serial.println("setTimeOfStroke: " + String(_timeOfStroke, 2));
 #endif
 
         // When running a pattern and immediate update requested:
-        if ((_state == PATTERN) && (applyNow == true)) {
+        if ((_state == PATTERN) && (applyNow == true))
+        {
             // set flag to apply update from stroking thread
             _applyUpdate = true;
 
-#ifdef DEBUG_TALKATIVE
-        Serial.println("Apply New Settings Now");
+#if DEBUG_STROKE_ENGINE
+            Serial.println("Apply New Settings Now");
 #endif
         }
 
@@ -76,30 +79,33 @@ void StrokeEngine::setSpeed(float speed, bool applyNow = false) {
     }
 }
 
-float StrokeEngine::getSpeed() {
+float StrokeEngine::getSpeed()
+{
     // Convert speed into FPMs
     return 60.0 / _timeOfStroke;
 }
 
-void StrokeEngine::setDepth(float depth, bool applyNow = false) {
-
-    if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE) {
+void StrokeEngine::setDepth(float depth, bool applyNow = false)
+{
+    if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE)
+    {
         // Convert depth from mm into steps
         // Constrain depth between minStep and maxStep
         _depth = constrain(int(depth * _motor->stepsPerMillimeter), _minStep, _maxStep);
 
         patternTable[_patternIndex]->setDepth(_depth);
 
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
         Serial.println("setDepth: " + String(_depth));
 #endif
         // When running a pattern and immediate update requested:
-        if ((_state == PATTERN) && (applyNow == true)) {
+        if ((_state == PATTERN) && (applyNow == true))
+        {
             // set flag to apply update from stroking thread
             _applyUpdate = true;
 
-#ifdef DEBUG_TALKATIVE
-        Serial.println("Apply New Settings Now");
+#if DEBUG_STROKE_ENGINE
+            Serial.println("Apply New Settings Now");
 #endif
         }
 
@@ -108,37 +114,41 @@ void StrokeEngine::setDepth(float depth, bool applyNow = false) {
     }
 
     // if in state SETUPDEPTH then adjust
-    if (_state == SETUPDEPTH) {
+    if (_state == SETUPDEPTH)
+    {
         _setupDepths();
     }
 }
 
-float StrokeEngine::getDepth() {
+float StrokeEngine::getDepth()
+{
     // Convert depth from steps into mm
     return _depth / _motor->stepsPerMillimeter;
 }
 
-void StrokeEngine::setStroke(float stroke, bool applyNow = false) {
+void StrokeEngine::setStroke(float stroke, bool applyNow = false)
+{
     // Update pattern with new stroke, will be used with the next stroke or on update request
-    if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE) {
-
+    if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE)
+    {
         // Convert stroke from mm into steps
         // Constrain stroke between minStep and maxStep
         _stroke = constrain(int(stroke * _motor->stepsPerMillimeter), _minStep, _maxStep);
 
         patternTable[_patternIndex]->setStroke(_stroke);
 
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
         Serial.println("setStroke: " + String(_stroke));
 #endif
 
         // When running a pattern and immediate update requested:
-        if ((_state == PATTERN) && (applyNow == true)) {
+        if ((_state == PATTERN) && (applyNow == true))
+        {
             // set flag to apply update from stroking thread
             _applyUpdate = true;
 
-#ifdef DEBUG_TALKATIVE
-        Serial.println("Apply New Settings Now");
+#if DEBUG_STROKE_ENGINE
+            Serial.println("Apply New Settings Now");
 #endif
         }
 
@@ -147,37 +157,40 @@ void StrokeEngine::setStroke(float stroke, bool applyNow = false) {
     }
 
     // if in state SETUPDEPTH then adjust
-    if (_state == SETUPDEPTH) {
+    if (_state == SETUPDEPTH)
+    {
         _setupDepths();
     }
 }
 
-float StrokeEngine::getStroke() {
+float StrokeEngine::getStroke()
+{
     // Convert stroke from steps into mm
     return _stroke / _motor->stepsPerMillimeter;
 }
 
-void StrokeEngine::setSensation(float sensation, bool applyNow = false) {
-
+void StrokeEngine::setSensation(float sensation, bool applyNow = false)
+{
     // Update pattern with new sensation, will be used with the next stroke or on update request
-    if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE) {
-
+    if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE)
+    {
         // Constrain sensation between -100 and 100
         _sensation = constrain(sensation, -100, 100);
 
         patternTable[_patternIndex]->setSensation(_sensation);
 
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
         Serial.println("setSensation: " + String(_sensation));
 #endif
 
         // When running a pattern and immediate update requested:
-        if ((_state == PATTERN) && (applyNow == true)) {
+        if ((_state == PATTERN) && (applyNow == true))
+        {
             // set flag to apply update from stroking thread
             _applyUpdate = true;
 
-#ifdef DEBUG_TALKATIVE
-        Serial.println("Apply New Settings Now");
+#if DEBUG_STROKE_ENGINE
+            Serial.println("Apply New Settings Now");
 #endif
         }
 
@@ -186,35 +199,42 @@ void StrokeEngine::setSensation(float sensation, bool applyNow = false) {
     }
 
     // if in state SETUPDEPTH then adjust
-    if (_state == SETUPDEPTH) {
+    if (_state == SETUPDEPTH)
+    {
         _setupDepths();
     }
 }
 
-float StrokeEngine::getSensation() {
+float StrokeEngine::getSensation()
+{
     return _sensation;
 }
 
-bool StrokeEngine::setPattern(int patternIndex, bool applyNow = false) {
+bool StrokeEngine::setPattern(int patternIndex, bool applyNow = false)
+{
     // Check wether pattern Index is in range
-    if ((patternIndex < patternTableSize) && (patternIndex >= 0)) {
+    if ((patternIndex < patternTableSize) && (patternIndex >= 0))
+    {
         _patternIndex = patternIndex;
 
         // Inject current motion parameters into new pattern
-        if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE) {
-            patternTable[_patternIndex]->setSpeedLimit(_maxStepPerSecond, _maxStepAcceleration, _motor->stepsPerMillimeter);
+        if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE)
+        {
+            patternTable[_patternIndex]->setSpeedLimit(_maxStepPerSecond, _maxStepAcceleration,
+                                                       _motor->stepsPerMillimeter);
             patternTable[_patternIndex]->setTimeOfStroke(_timeOfStroke);
             patternTable[_patternIndex]->setStroke(_stroke);
             patternTable[_patternIndex]->setDepth(_depth);
             patternTable[_patternIndex]->setSensation(_sensation);
 
             // When running a pattern and immediate update requested:
-            if ((_state == PATTERN) && (applyNow == true)) {
+            if ((_state == PATTERN) && (applyNow == true))
+            {
                 // set flag to apply update from stroking thread
                 _applyUpdate = true;
 
-#ifdef DEBUG_TALKATIVE
-            Serial.println("Apply New Settings Now");
+#if DEBUG_STROKE_ENGINE
+                Serial.println("Apply New Settings Now");
 #endif
             }
 
@@ -225,33 +245,36 @@ bool StrokeEngine::setPattern(int patternIndex, bool applyNow = false) {
         // Reset index counter
         _index = 0;
 
-#ifdef DEBUG_TALKATIVE
-    Serial.println("setPattern: [" + String(_patternIndex) + "] " + patternTable[_patternIndex]->getName());
-    Serial.println("setTimeOfStroke: " + String(_timeOfStroke, 2));
-    Serial.println("setDepth: " + String(_depth));
-    Serial.println("setStroke: " + String(_stroke));
-    Serial.println("setSensation: " + String(_sensation));
+#if DEBUG_STROKE_ENGINE
+        Serial.println("setPattern: [" + String(_patternIndex) + "] " + patternTable[_patternIndex]->getName());
+        Serial.println("setTimeOfStroke: " + String(_timeOfStroke, 2));
+        Serial.println("setDepth: " + String(_depth));
+        Serial.println("setStroke: " + String(_stroke));
+        Serial.println("setSensation: " + String(_sensation));
 #endif
         return true;
     }
 
     // Return false on no match
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
     Serial.println("Failed to set pattern: " + String(_patternIndex));
 #endif
     return false;
 }
 
-int StrokeEngine::getPattern() {
+int StrokeEngine::getPattern()
+{
     return _patternIndex;
 }
 
-bool StrokeEngine::startPattern() {
+bool StrokeEngine::startPattern()
+{
     // Only valid if state is ready
-    if (_state == READY || _state == SETUPDEPTH) {
-
+    if (_state == READY || _state == SETUPDEPTH)
+    {
         // Stop current move, should one be pending (moveToMax or moveToMin)
-        if (servo->isRunning()) {
+        if (servo->isRunning())
+        {
             // Stop servo motor as fast as legally allowed
             servo->setAcceleration(_maxStepAcceleration);
             servo->applySpeedAcceleration();
@@ -263,8 +286,10 @@ bool StrokeEngine::startPattern() {
 
         // Reset Stroke and Motion parameters
         _index = -1;
-        if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE) {
-            patternTable[_patternIndex]->setSpeedLimit(_maxStepPerSecond, _maxStepAcceleration, _motor->stepsPerMillimeter);
+        if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE)
+        {
+            patternTable[_patternIndex]->setSpeedLimit(_maxStepPerSecond, _maxStepAcceleration,
+                                                       _motor->stepsPerMillimeter);
             patternTable[_patternIndex]->setTimeOfStroke(_timeOfStroke);
             patternTable[_patternIndex]->setStroke(_stroke);
             patternTable[_patternIndex]->setDepth(_depth);
@@ -272,50 +297,52 @@ bool StrokeEngine::startPattern() {
             xSemaphoreGive(_patternMutex);
         }
 
-
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
         Serial.print(" _timeOfStroke: " + String(_timeOfStroke));
         Serial.print(" | _depth: " + String(_depth));
         Serial.print(" | _stroke: " + String(_stroke));
         Serial.println(" | _sensation: " + String(_sensation));
 #endif
 
-        if (_taskStrokingHandle == NULL) {
+        if (_taskStrokingHandle == NULL)
+        {
             // Create Stroke Task
-            xTaskCreatePinnedToCore(
-                this->_strokingImpl,    // Function that should be called
-                "Stroking",             // Name of the task (for debugging)
-                4096,                   // Stack size (bytes)
-                this,                   // Pass reference to this class instance
-                2,                     // Pretty high task priority
-                &_taskStrokingHandle,   // Task handle
-                1                       // Pin to application core
+            xTaskCreatePinnedToCore(this->_strokingImpl,  // Function that should be called
+                                    "Stroking",           // Name of the task (for debugging)
+                                    4096,                 // Stack size (bytes)
+                                    this,                 // Pass reference to this class instance
+                                    2,                    // Pretty high task priority
+                                    &_taskStrokingHandle, // Task handle
+                                    1                     // Pin to application core
             );
-        } else {
+        }
+        else
+        {
             // Resume task, if it already exists
             vTaskResume(_taskStrokingHandle);
         }
 
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
         Serial.println("Started motion task");
         Serial.println("Stroke Engine State: " + verboseState[_state]);
 #endif
 
         return true;
-
-    } else {
-
-#ifdef DEBUG_TALKATIVE
+    }
+    else
+    {
+#if DEBUG_STROKE_ENGINE
         Serial.println("Failed to start motion");
 #endif
         return false;
-
     }
 }
 
-void StrokeEngine::stopMotion() {
+void StrokeEngine::stopMotion()
+{
     // only valid when
-    if (_state == PATTERN || _state == SETUPDEPTH) {
+    if (_state == PATTERN || _state == SETUPDEPTH)
+    {
         // Set state
         _state = READY;
 
@@ -324,25 +351,28 @@ void StrokeEngine::stopMotion() {
         servo->applySpeedAcceleration();
         servo->stopMove();
 
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
         Serial.println("Motion stopped");
 #endif
 
         // Wait for servo stopped
-        while (servo->isRunning());
+        while (servo->isRunning())
+            ;
 
         // Send telemetry data
-        if (_callbackTelemetry != NULL) {
+        if (_callbackTelemetry != NULL)
+        {
             _callbackTelemetry(float(servo->getCurrentPosition() / _motor->stepsPerMillimeter), 0.0, false);
         }
     }
 
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
     Serial.println("Stroke Engine State: " + verboseState[_state]);
 #endif
 }
 
-void StrokeEngine::enableAndHome(endstopProperties *endstop, void(*callBackHoming)(bool), float speed) {
+void StrokeEngine::enableAndHome(endstopProperties *endstop, void (*callBackHoming)(bool), float speed)
+{
     // Store callback
     _callBackHomeing = callBackHoming;
 
@@ -350,7 +380,8 @@ void StrokeEngine::enableAndHome(endstopProperties *endstop, void(*callBackHomin
     enableAndHome(endstop, speed);
 }
 
-void StrokeEngine::enableAndHome(endstopProperties *endstop, float speed) {
+void StrokeEngine::enableAndHome(endstopProperties *endstop, float speed)
+{
     // set homing pin as input
     _homeingPin = endstop->endstopPin;
     pinMode(_homeingPin, endstop->pinMode);
@@ -358,9 +389,12 @@ void StrokeEngine::enableAndHome(endstopProperties *endstop, float speed) {
     _homeingSpeed = speed * _motor->stepsPerMillimeter;
 
     // set homing direction so sign can be multiplied
-    if (endstop->homeToBack == true) {
+    if (endstop->homeToBack == true)
+    {
         _homeingToBack = 1;
-    } else {
+    }
+    else
+    {
         _homeingToBack = -1;
     }
 
@@ -371,26 +405,26 @@ void StrokeEngine::enableAndHome(endstopProperties *endstop, float speed) {
     servo->enableOutputs();
 
     // Create homing task
-    xTaskCreatePinnedToCore(
-        this->_homingProcedureImpl,     // Function that should be called
-        "Homing",                       // Name of the task (for debugging)
-        2048,                           // Stack size (bytes)
-        this,                           // Pass reference to this class instance
-        1,                             // Pretty high task priority
-        &_taskHomingHandle,             // Task handle
-        1                               // Have it on application core
+    xTaskCreatePinnedToCore(this->_homingProcedureImpl, // Function that should be called
+                            "Homing",                   // Name of the task (for debugging)
+                            2048,                       // Stack size (bytes)
+                            this,                       // Pass reference to this class instance
+                            1,                          // Pretty high task priority
+                            &_taskHomingHandle,         // Task handle
+                            1                           // Have it on application core
     );
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
     Serial.println("Homing task started");
 #endif
-
 }
 
-void StrokeEngine::thisIsHome(float speed) {
+void StrokeEngine::thisIsHome(float speed)
+{
     // set homeing speed
     _homeingSpeed = speed * _motor->stepsPerMillimeter;
 
-    if (_state == UNDEFINED) {
+    if (_state == UNDEFINED)
+    {
         // Enable Servo
         servo->enableOutputs();
 
@@ -408,26 +442,26 @@ void StrokeEngine::thisIsHome(float speed) {
         _isHomed = true;
         _state = READY;
 
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
         Serial.println("This is Home now");
 #endif
 
         return;
     }
 
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
     Serial.println("Manual homing failed. Not in state UNDEFINED");
 #endif
-
 }
 
-bool StrokeEngine::moveToMax(float speed) {
-
-#ifdef DEBUG_TALKATIVE
+bool StrokeEngine::moveToMax(float speed)
+{
+#if DEBUG_STROKE_ENGINE
     Serial.println("Move to max");
 #endif
 
-    if (_isHomed) {
+    if (_isHomed)
+    {
         // Stop motion immediately
         stopMotion();
 
@@ -438,30 +472,33 @@ bool StrokeEngine::moveToMax(float speed) {
         servo->moveTo(_maxStep);
 
         // Send telemetry data
-        if (_callbackTelemetry != NULL) {
+        if (_callbackTelemetry != NULL)
+        {
             _callbackTelemetry(float(_maxStep / _motor->stepsPerMillimeter), speed, false);
         }
 
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
         Serial.println("Stroke Engine State: " + verboseState[_state]);
 #endif
 
         // Return success
         return true;
-
-    } else {
+    }
+    else
+    {
         // Return failure
         return false;
     }
 }
 
-bool StrokeEngine::moveToMin(float speed) {
-
-#ifdef DEBUG_TALKATIVE
+bool StrokeEngine::moveToMin(float speed)
+{
+#if DEBUG_STROKE_ENGINE
     Serial.println("Move to min");
 #endif
 
-    if (_isHomed) {
+    if (_isHomed)
+    {
         // Stop motion immediately
         stopMotion();
 
@@ -472,25 +509,28 @@ bool StrokeEngine::moveToMin(float speed) {
         servo->moveTo(_minStep);
 
         // Send telemetry data
-        if (_callbackTelemetry != NULL) {
+        if (_callbackTelemetry != NULL)
+        {
             _callbackTelemetry(float(_minStep / _motor->stepsPerMillimeter), speed, false);
         }
 
-#ifdef DEBUG_TALKATIVE
-    Serial.println("Stroke Engine State: " + verboseState[_state]);
+#if DEBUG_STROKE_ENGINE
+        Serial.println("Stroke Engine State: " + verboseState[_state]);
 #endif
 
         // Return success
         return true;
-
-    } else {
+    }
+    else
+    {
         // Return failure
         return false;
     }
 }
 
-bool StrokeEngine::setupDepth(float speed, bool fancy) {
-#ifdef DEBUG_TALKATIVE
+bool StrokeEngine::setupDepth(float speed, bool fancy)
+{
+#if DEBUG_STROKE_ENGINE
     Serial.println("Move to Depth");
 #endif
     // store fanciness
@@ -500,7 +540,8 @@ bool StrokeEngine::setupDepth(float speed, bool fancy) {
     bool allowed = false;
 
     // isHomed is only true in states READY, PATTERN and SETUPDEPTH
-    if (_isHomed) {
+    if (_isHomed)
+    {
         // Stop motion immediately
         stopMotion();
 
@@ -518,17 +559,19 @@ bool StrokeEngine::setupDepth(float speed, bool fancy) {
         // set return value to true
         allowed = true;
     }
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
     Serial.println("Stroke Engine State: " + verboseState[_state]);
 #endif
     return allowed;
 }
 
-ServoState StrokeEngine::getState() {
+ServoState StrokeEngine::getState()
+{
     return _state;
 }
 
-void StrokeEngine::disable() {
+void StrokeEngine::disable()
+{
     _state = UNDEFINED;
     _isHomed = false;
 
@@ -536,30 +579,35 @@ void StrokeEngine::disable() {
     servo->disableOutputs();
 
     // Delete homing Task
-    if (_taskHomingHandle != NULL) {
+    if (_taskHomingHandle != NULL)
+    {
         vTaskDelete(_taskHomingHandle);
         _taskHomingHandle = NULL;
     }
 
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
     Serial.println("Servo disabled. Call home to continue.");
     Serial.println("Stroke Engine State: " + verboseState[_state]);
 #endif
-
 }
 
-String StrokeEngine::getPatternName(int index) {
-    if (index >= 0 && index <= patternTableSize) {
+String StrokeEngine::getPatternName(int index)
+{
+    if (index >= 0 && index <= patternTableSize)
+    {
         return String(patternTable[index]->getName());
-    } else {
+    }
+    else
+    {
         return String("Invalid");
     }
-
 }
 
-void StrokeEngine::setMaxSpeed(float maxSpeed){
+void StrokeEngine::setMaxSpeed(float maxSpeed)
+{
     // Update pattern with new speed limits
-    if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE) {
+    if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE)
+    {
         // Convert speed into steps
         _maxStepPerSecond = int(0.5 + _motor->maxSpeed * _motor->stepsPerMillimeter);
         patternTable[_patternIndex]->setSpeedLimit(_maxStepPerSecond, _maxStepAcceleration, _motor->stepsPerMillimeter);
@@ -567,14 +615,16 @@ void StrokeEngine::setMaxSpeed(float maxSpeed){
     }
 }
 
-float StrokeEngine::getMaxSpeed() {
+float StrokeEngine::getMaxSpeed()
+{
     return float(_maxStepPerSecond / _motor->stepsPerMillimeter);
 }
 
-void StrokeEngine::setMaxAcceleration(float maxAcceleration) {
-
+void StrokeEngine::setMaxAcceleration(float maxAcceleration)
+{
     // Update pattern with new speed limits
-    if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE) {
+    if (xSemaphoreTake(_patternMutex, portMAX_DELAY) == pdTRUE)
+    {
         // Convert acceleration into steps
         _maxStepAcceleration = int(0.5 + _motor->maxAcceleration * _motor->stepsPerMillimeter);
         patternTable[_patternIndex]->setSpeedLimit(_maxStepPerSecond, _maxStepAcceleration, _motor->stepsPerMillimeter);
@@ -582,54 +632,63 @@ void StrokeEngine::setMaxAcceleration(float maxAcceleration) {
     }
 }
 
-float StrokeEngine::getMaxAcceleration() {
+float StrokeEngine::getMaxAcceleration()
+{
     return float(_maxStepAcceleration / _motor->stepsPerMillimeter);
 }
 
-void StrokeEngine::registerTelemetryCallback(void(*callbackTelemetry)(float, float, bool)) {
+void StrokeEngine::registerTelemetryCallback(void (*callbackTelemetry)(float, float, bool))
+{
     _callbackTelemetry = callbackTelemetry;
 }
 
-void StrokeEngine::_homingProcedure() {
+void StrokeEngine::_homingProcedure()
+{
     // Set feedrate for homing
     servo->setSpeedInHz(_homeingSpeed);
     servo->setAcceleration(_maxStepAcceleration / 10);
 
     // Check if we are already at the homing switch
-    if (digitalRead(_homeingPin) == !_homeingActiveLow) {
-        //back off 5 mm from switch
+    if (digitalRead(_homeingPin) == !_homeingActiveLow)
+    {
+        // back off 5 mm from switch
         servo->move(_motor->stepsPerMillimeter * 2 * _physics->keepoutBoundary * _homeingToBack);
 
         // wait for move to complete
-        while (servo->isRunning()) {
+        while (servo->isRunning())
+        {
             // Pause the task for 100ms while waiting for move to complete
             vTaskDelay(100 / portTICK_PERIOD_MS);
         }
 
         // move back towards endstop
         servo->move(-_motor->stepsPerMillimeter * 4 * _physics->keepoutBoundary * _homeingToBack);
-
-    } else {
+    }
+    else
+    {
         // Move MAX_TRAVEL towards the homing switch
         servo->move(-_motor->stepsPerMillimeter * _physics->physicalTravel * _homeingToBack);
     }
 
     // Poll homing switch
-    while (servo->isRunning()) {
-
+    while (servo->isRunning())
+    {
         // Switch is active low
-        if (digitalRead(_homeingPin) == !_homeingActiveLow) {
-
+        if (digitalRead(_homeingPin) == !_homeingActiveLow)
+        {
             // Set home position
-            if (_homeingToBack == 1) {
-                //Switch is at -KEEPOUT_BOUNDARY
+            if (_homeingToBack == 1)
+            {
+                // Switch is at -KEEPOUT_BOUNDARY
                 servo->forceStopAndNewPosition(-_motor->stepsPerMillimeter * _physics->keepoutBoundary);
 
                 // drive free of switch and set axis to lower end
                 servo->moveTo(_minStep);
-
-            } else {
-                servo->forceStopAndNewPosition(_motor->stepsPerMillimeter * (_physics->physicalTravel - _physics->keepoutBoundary));
+            }
+            else
+            {
+                servo->forceStopAndNewPosition(_motor->stepsPerMillimeter *
+                                               (_physics->physicalTravel - _physics->keepoutBoundary));
 
                 // drive free of switch and set axis to front end
                 servo->moveTo(_maxStep);
@@ -648,34 +707,38 @@ void StrokeEngine::_homingProcedure() {
     }
 
     // disable Servo if homing has not found the homing switch
-    if (!_isHomed) {
+    if (!_isHomed)
+    {
         servo->disableOutputs();
         _state = UNDEFINED;
 
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
         Serial.println("Homing failed");
 #endif
-
-    } else {
+    }
+    else
+    {
         // Set state to ready
         _state = READY;
 
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
         Serial.println("Homing succeeded");
 #endif
     }
 
     // Call notification callback, if it was defined.
-    if (_callBackHomeing != NULL) {
+    if (_callBackHomeing != NULL)
+    {
         _callBackHomeing(_isHomed);
     }
 
     // Set first point for telemetry
-    if (_callbackTelemetry != NULL) {
+    if (_callbackTelemetry != NULL)
+    {
         _callbackTelemetry(0.0, 0.0, false);
     }
 
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
     Serial.println("Stroke Engine State: " + verboseState[_state]);
 #endif
 
@@ -684,25 +747,30 @@ void StrokeEngine::_homingProcedure() {
     vTaskDelete(NULL);
 }
 
-void StrokeEngine::_stroking() {
+void StrokeEngine::_stroking()
+{
     motionParameter currentMotion;
 
-    while(1) { // infinite loop
+    while (1)
+    { // infinite loop
 
         // Suspend task, if not in PATTERN state
-        if (_state != PATTERN) {
+        if (_state != PATTERN)
+        {
             vTaskSuspend(_taskStrokingHandle);
         }
 
         // Take mutex to ensure no interference / race condition with communication threat on other core
-        if (xSemaphoreTake(_patternMutex, 0) == pdTRUE) {
-
-            if (_applyUpdate == true) {
+        if (xSemaphoreTake(_patternMutex, 0) == pdTRUE)
+        {
+            if (_applyUpdate == true)
+            {
                 // Ask pattern for update on motion parameters
                 currentMotion = patternTable[_patternIndex]->nextTarget(_index);
 
                 // Increase deceleration if required to avoid crash
-                if (servo->getAcceleration() > currentMotion.acceleration) {
+                if (servo->getAcceleration() > currentMotion.acceleration)
+                {
 #ifdef DEBUG_CLIPPING
                     Serial.print("Crash avoidance! Set Acceleration from " + String(currentMotion.acceleration));
                     Serial.println(" to " + String(servo->getAcceleration()));
@@ -718,8 +786,8 @@ void StrokeEngine::_stroking() {
             }
 
             // If motor has stopped issue moveTo command to next position
-            else if (servo->isRunning() == false) {
-
+            else if (servo->isRunning() == false)
+            {
                 // Increment index for pattern
                 _index++;
 
@@ -727,15 +795,16 @@ void StrokeEngine::_stroking() {
                 currentMotion = patternTable[_patternIndex]->nextTarget(_index);
 
                 // Pattern may introduce pauses between strokes
-                if (currentMotion.skip == false) {
-
+                if (currentMotion.skip == false)
+                {
 #ifdef DEBUG_STROKE
                     Serial.println("Stroking Index: " + String(_index));
 #endif
                     // Apply new trapezoidal motion profile to servo
                     _applyMotionProfile(&currentMotion);
-
-                } else {
+                }
+                else
+                {
                     // decrement _index so that it stays the same until the next valid stroke parameters are delivered
                     _index--;
                 }
@@ -750,12 +819,14 @@ void StrokeEngine::_stroking() {
     }
 }
 
-void StrokeEngine::_streaming() {
-
-    while(1) { // infinite loop
+void StrokeEngine::_streaming()
+{
+    while (1)
+    { // infinite loop
 
         // Suspend task, if not in STREAMING state
-        if (_state != STREAMING) {
+        if (_state != STREAMING)
+        {
             vTaskSuspend(_taskStreamingHandle);
         }
 
@@ -764,30 +835,34 @@ void StrokeEngine::_streaming() {
     }
 }
 
-void StrokeEngine::_applyMotionProfile(motionParameter* motion) {
-
+void StrokeEngine::_applyMotionProfile(motionParameter *motion)
+{
     bool clipping = false;
     float speed = 0.0;
     float position = 0.0;
 
     // Apply new trapezoidal motion profile to servo if pattern does not skip
-    if (motion->skip == false) {
-
+    if (motion->skip == false)
+    {
         // Constrain speed to below _maxStepPerSecond
-        if (motion->speed > _maxStepPerSecond) {
+        if (motion->speed > _maxStepPerSecond)
+        {
 #ifdef DEBUG_CLIPPING
-        Serial.println("Max Speed Exceeded: " + String(float(motion->speed / _motor->stepsPerMillimeter), 2)
-                + "mm/s --> Limit: " + String(float(_maxStepPerSecond / _motor->stepsPerMillimeter), 2) + "mm/s");
+            Serial.println("Max Speed Exceeded: " + String(float(motion->speed / _motor->stepsPerMillimeter), 2) +
+                           "mm/s --> Limit: " + String(float(_maxStepPerSecond / _motor->stepsPerMillimeter), 2) +
+                           "mm/s");
 #endif
             motion->speed = _maxStepPerSecond;
             clipping = true;
         }
 
         // Constrain acceleration between 1 step/sec^2 and _maxStepAcceleration
-        if (motion->acceleration > _maxStepAcceleration) {
+        if (motion->acceleration > _maxStepAcceleration)
+        {
 #ifdef DEBUG_CLIPPING
-        Serial.println("Max Acceleration Exceeded: " + String(float(motion->acceleration / _motor->stepsPerMillimeter), 2)
-                + "mm/s² --> Limit: " + String(float(_maxStepAcceleration / _motor->stepsPerMillimeter), 2) + "mm/s²");
+            Serial.println(
+                "Max Acceleration Exceeded: " + String(float(motion->acceleration / _motor->stepsPerMillimeter), 2) +
+                "mm/s² --> Limit: " + String(float(_maxStepAcceleration / _motor->stepsPerMillimeter), 2) + "mm/s²");
 #endif
             motion->acceleration = _maxStepAcceleration;
             clipping = true;
@@ -806,32 +881,34 @@ void StrokeEngine::_applyMotionProfile(motionParameter* motion) {
         position = float(pos / _motor->stepsPerMillimeter);
 
 #ifdef DEBUG_STROKE
-    Serial.println("motion.stroke: " + String(position, 2) + "mm");
-    Serial.println("motion.speed: " + String(speed, 2) + "mm/s");
-    Serial.println("motion.acceleration: " + String(float(motion->acceleration / _motor->stepsPerMillimeter), 2) + "mm/s²");
+        Serial.println("motion.stroke: " + String(position, 2) + "mm");
+        Serial.println("motion.speed: " + String(speed, 2) + "mm/s");
+        Serial.println("motion.acceleration: " + String(float(motion->acceleration / _motor->stepsPerMillimeter), 2) +
+                       "mm/s²");
 #endif
 
         // Send telemetry data
-        if (_callbackTelemetry != NULL) {
+        if (_callbackTelemetry != NULL)
+        {
             _callbackTelemetry(position, speed, clipping);
         }
     }
 }
 
-void StrokeEngine::_setupDepths() {
+void StrokeEngine::_setupDepths()
+{
     // set depth to _depth
     int depth = _depth;
 
     // in fancy mode we need to calculate exact position based on sensation, stroke & depth
-    if (_fancyAdjustment == true) {
+    if (_fancyAdjustment == true)
+    {
         // map sensation into the interval [depth-stroke, depth]
         depth = map(_sensation, -100, 100, _depth - _stroke, _depth);
 
-#ifdef DEBUG_TALKATIVE
-        Serial.println("map sensation " + String(_sensation)
-            + " to interval [" + String(_depth - _stroke)
-            + ", " + String(_depth)
-            + "] = " + String(depth));
+#if DEBUG_STROKE_ENGINE
+        Serial.println("map sensation " + String(_sensation) + " to interval [" + String(_depth - _stroke) + ", " +
+                       String(_depth) + "] = " + String(depth));
 #endif
     }
 
@@ -839,14 +916,13 @@ void StrokeEngine::_setupDepths() {
     servo->moveTo(depth);
 
     // Send telemetry data
-    if (_callbackTelemetry != NULL) {
+    if (_callbackTelemetry != NULL)
+    {
         _callbackTelemetry(float(depth / _motor->stepsPerMillimeter),
-            float(servo->getSpeedInMilliHz() * 1000 / _motor->stepsPerMillimeter),
-            false);
+                           float(servo->getSpeedInMilliHz() * 1000 / _motor->stepsPerMillimeter), false);
     }
 
-#ifdef DEBUG_TALKATIVE
+#if DEBUG_STROKE_ENGINE
     Serial.println("setup new depth: " + String(depth));
 #endif
 }
-

--- a/PlatformIO ESP32 code/OSSM_ESP32/platformio.ini
+++ b/PlatformIO ESP32 code/OSSM_ESP32/platformio.ini
@@ -17,3 +17,6 @@ upload_speed = 921600
 monitor_speed = 115200
 monitor_flags =
             --rtscts
+
+lib_deps =
+        ModbusClient=https://github.com/eModbus/eModbus.git

--- a/PlatformIO ESP32 code/OSSM_ESP32/src/OSSM_Config.h
+++ b/PlatformIO ESP32 code/OSSM_ESP32/src/OSSM_Config.h
@@ -1,33 +1,91 @@
 #ifndef OSSM_CONFIG_H
 #define OSSM_CONFIG_H
 
+///////////////////////////////
+///     DEBUG SETTINGS     ///
+/////////////////////////////
 
-#define DEBUG
+// Global debug flag, unset to remove all debug outputs (not recommended)
+#define DEBUG true
 
-#ifdef DEBUG
-#define LogDebug(...) Serial.println(__VA_ARGS__)
-#define LogDebugFormatted(...) Serial.printf(__VA_ARGS__)
+#if DEBUG
+    #define LogDebug(...) Serial.println(__VA_ARGS__)
+    #define LogDebugFormatted(...) Serial.printf(__VA_ARGS__)
+
+    //// more granular debug settings ////
+    // Set to get positional helpers (ie "looping" at the beginning of each loop() execution)
+    #define DEBUG_CODE_POSITIONS false
+    // Set to get periotic updates on the total number of strokes / power up time / distance fucked
+    #define PRINT_STATS false
+    // Set to spam pre-mode-selection encoder info. Useful if choosing "Simple Penetration" or "Stroke engine" is not
+    // working
+    #define PRINT_ENCODER_INFO_BEFORE_MODE false
+    // Set to spam position, current info during homeing procedure
+    #define PRINT_HOMING_INFO false
+
+    // StrokeEngine specific debug messages
+    #define DEBUG_STROKE_ENGINE true
 #else
-#define LogDebug(...) ((void)0)
-#define LogDebugFormatted(...) ((void)0)
+    #define LogDebug(...) ((void)0)
+    #define LogDebugFormatted(...) ((void)0)
 #endif
 
+///////////////////////////////
+///     FEATURE FLAGS      ///
+/////////////////////////////
+
+// Enables the torque setting (accessable by triple clicking)
+#define SERVO_MOTOR_VERSION 6 // valid values = [5, 6]
+#define SERVO_TORQUE_SETTING true
+
+// Controls how internet connected the OSSM is
+//   0 = no wifi at all
+//   1 = local wifi only (not functionally implemented)
+//   2 = internet connected / remote update only
+//   3 = internet connected / remote update and control (default)
+#define INTERNET_CONNECTION_MODE 3
+
+// Don't mess with these unless you are who you know you are ;)
+#define INTERNET_CONNECTION_TEST_SERVER false
+#define OTA_TEST_FIRMWARE false
+
+///////////////////////////////
+///      VERSION INFO      ///
+/////////////////////////////
 #define SW_VERSION "0.23"
-#define HW_VERSION 22 //divide by 10 for real hw version
+#define HW_VERSION 23 // divide by 10 for real hw version
 #define EEPROM_SIZE 200
+// #define INITIAL_SETUP //should only be defined at initial burn to configure HW version
 
-//#define INITIAL_SETUP //should only be defined at initial burn to configure HW version
-
+///////////////////////////////
+///      VOLATILE VARS     ///
+/////////////////////////////
 extern volatile int encoderButtonPresses;
 extern volatile long lastEncoderButtonPressMillis;
 
+///////////////////////////////
+///       USER CONFIG      ///
+/////////////////////////////
 /*
-    User Config for OSSM - Reference board users should tweak this to match their personal build.
+    UI config
 */
-
+// time window in miliseconds that clicks will register as double / triple clicks, rather than individual clicks.
+//   raise if its hard to get into pattern / force mode
+//   lower if you mean to cycle between stroke / depth / sensation, but instead you end up in pattern / force mode
+const int MULTI_CLICK_SPEED = 250;
+// time window that if two clicks happens within, only one counts. This it due to buttons being "noisy" when being
+//   pressed. Without this a single click will register as multiple. If you have a motion disability, such as
+//   parkensons, where you inadvertantly press things multiple times, you can raise this value to be higher to tune out
+//   accedental inputs (you will need to change MULTI_CLICK_SPEED accordingly)
+const int CLICK_DEBOUNCE_SPEED = 50;
 /*
-        Motion System Config
+    Motion System Config
 */
+// Min & Max torque settings. override this if you want a harder pounding. the iHSV57 defaults to 13
+const int MIN_FORCE = 2;
+const int MAX_FORCE = 11;
+// Safety value for the setForce function. If a value is given higher than this, it will be ignored
+const int MAX_SAFETY_FORCE = max(MAX_FORCE, 13);
 // Top linear speed of the device.
 const float hardcode_maxSpeedMmPerSecond = 900.0f;
 // This should match the step/rev of your stepper or servo.
@@ -43,6 +101,7 @@ const float hardcode_beltPitchMm = 2.0f;
 // the linear block holder length (75mm on OSSM)
 // Recommended to also subtract e.g. 20mm to keep the backstop well away from the device.
 const float hardcode_maxStrokeLengthMm = 75.f;
+
 /*
         Web Config
 */

--- a/PlatformIO ESP32 code/OSSM_ESP32/src/OSSM_Main.cpp
+++ b/PlatformIO ESP32 code/OSSM_ESP32/src/OSSM_Main.cpp
@@ -1,0 +1,386 @@
+#include <Arduino.h>          // Basic Needs
+#include <ArduinoJson.h>      // Needed for the Bubble APP
+#include <ESP_FlexyStepper.h> // Current Motion Control
+#include <Encoder.h>          // Used for the Remote Encoder Input
+#include <HTTPClient.h>       // Needed for the Bubble APP
+#include <WiFiManager.h>      // Used to provide easy network connection  https://github.com/tzapu/WiFiManager
+#include <Wire.h>             // Used for i2c connections (Remote OLED Screen)
+
+#include "OSSM_Config.h" // START HERE FOR Configuration
+#include "OSSM_PinDef.h" // This is where you set pins specific for your board
+#include "OssmUi.h"      // Separate file that helps contain the OLED screen functions
+#include "Stroke_Engine_Helper.h"
+#include "Utilities.h" // Utility helper functions - wifi update and homing
+
+// Homing
+volatile bool g_has_not_homed = true;
+bool REMOTE_ATTACHED = false;
+
+// OSSM name setup
+const char *ossmId = "OSSM1";
+volatile int encoderButtonPresses = 0; // increment for each click
+volatile long lastEncoderButtonPressMillis = 0;
+
+IRAM_ATTR void encoderPushButton()
+{
+    // TODO: Toggle position mode
+    // g_encoder.write(0);       // Reset on Button Push
+    // ossm.g_ui.NextFrame();         // Next Frame on Button Push
+
+    // debounce check
+    long currentTime = millis();
+    if ((currentTime - lastEncoderButtonPressMillis) > CLICK_DEBOUNCE_SPEED)
+    {
+        // run interrupt if not run in last 50ms
+        encoderButtonPresses++;
+        lastEncoderButtonPressMillis = currentTime;
+    }
+}
+
+// Current command state
+// volatile float strokePercentage = 0;
+// volatile float ossm.speedPercentage = 0;
+// volatile float deceleration = 0;
+
+// Create tasks for checking pot input or web server control, and task to handle
+// planning the motion profile (this task is high level only and does not pulse
+// the stepper!)
+TaskHandle_t wifiTask = nullptr;
+TaskHandle_t getInputTask = nullptr;
+TaskHandle_t motionTask = nullptr;
+TaskHandle_t estopTask = nullptr;
+TaskHandle_t oledTask = nullptr;
+
+// Declarations
+// TODO: Document functions
+// void setLedRainbow(CRGB leds[]);
+void getUserInputTask(void *pvParameters);
+void motionCommandTask(void *pvParameters);
+void wifiConnectionTask(void *pvParameters);
+void estopResetTask(void *pvParameters);
+
+bool setInternetControl(bool wifiControlEnable);
+bool getInternetSettings();
+
+bool stopSwitchTriggered = 0;
+
+// create the OSSM hardware object
+OSSM ossm;
+
+///////////////////////////////////////////
+////
+////  VOID SETUP -- Here's where it's hiding
+////
+///////////////////////////////////////////
+
+void setup()
+{
+    ossm.startLeds();
+    Serial.begin(115200);
+    LogDebug("\n Starting");
+    pinMode(ENCODER_SWITCH, INPUT_PULLDOWN); // Rotary Encoder Pushbutton
+    attachInterrupt(digitalPinToInterrupt(ENCODER_SWITCH), encoderPushButton, RISING);
+
+    ossm.setup();
+    ossm.setupModbusAndReportState();
+    ossm.findHome();
+
+    ossm.setRunMode();
+
+    // Kick off the http and motion tasks - they begin executing as soon as they
+    // are created here! Do not change the priority of the task, or do so with
+    // caution. RTOS runs first in first out, so if there are no delays in your
+    // tasks they will prevent all other code from running on that core!
+    xTaskCreatePinnedToCore(getUserInputTask,   /* Task function. */
+                            "getUserInputTask", /* name of task. */
+                            10000,              /* Stack size of task */
+                            NULL,               /* parameter of the task */
+                            1,                  /* priority of the task */
+                            &getInputTask,      /* Task handle to keep track of created task */
+                            0);                 /* pin task to core 0 */
+    delay(100);
+    xTaskCreatePinnedToCore(motionCommandTask,   /* Task function. */
+                            "motionCommandTask", /* name of task. */
+                            20000,               /* Stack size of task */
+                            NULL,                /* parameter of the task */
+                            1,                   /* priority of the task */
+                            &motionTask,         /* Task handle to keep track of created task */
+                            0);                  /* pin task to core 0 */
+
+    delay(100);
+    xTaskCreatePinnedToCore(estopResetTask,   /* Task function. */
+                            "estopResetTask", /* name of task. */
+                            10000,            /* Stack size of task */
+                            NULL,             /* parameter of the task */
+                            1,                /* priority of the task */
+                            &estopTask,       /* Task handle to keep track of created task */
+                            0);               /* pin task to core 0 */
+
+    delay(100);
+    ossm.g_ui.UpdateMessage("OSSM Ready to Play");
+} // Void Setup()
+
+///////////////////////////////////////////
+////
+////
+////   VOID LOOP - Hides here
+////
+////
+///////////////////////////////////////////
+
+void loop()
+{
+    switch (ossm.rightKnobMode)
+    {
+        case MODE_STROKE:
+            ossm.g_ui.UpdateState("STROKE", static_cast<int>(ossm.speedPercentage),
+                                  static_cast<int>(ossm.strokePercentage + 0.5f));
+            break;
+        case MODE_DEPTH:
+            ossm.g_ui.UpdateState("DEPTH", static_cast<int>(ossm.speedPercentage),
+                                  static_cast<int>(ossm.depthPercentage + 0.5f));
+            break;
+        case MODE_SENSATION:
+            ossm.g_ui.UpdateState("SENSTN", static_cast<int>(ossm.speedPercentage),
+                                  static_cast<int>(ossm.sensationPercentage + 0.5f));
+            break;
+        case MODE_PATTERN:
+            ossm.g_ui.UpdateState("PATTRN", static_cast<int>(ossm.speedPercentage),
+                                  ossm.strokePattern * 100 / (ossm.strokePatternCount - 1));
+            break;
+        case MODE_FORCE:
+            ossm.g_ui.UpdateState("FORCE", static_cast<int>(ossm.speedPercentage),
+                                  static_cast<int>(ossm.forcePercentage + 0.05f));
+            break;
+    }
+    ossm.g_ui.UpdateScreen();
+
+    // debug
+    static bool is_connected = false;
+    if (!is_connected && ossm.g_ui.DisplayIsConnected())
+    {
+        LogDebug("Display Connected");
+        is_connected = true;
+    }
+    else if (is_connected && !ossm.g_ui.DisplayIsConnected())
+    {
+        LogDebug("Display Disconnected");
+        is_connected = false;
+    }
+}
+
+///////////////////////////////////////////
+////
+////
+////  freeRTOS multitasking
+////
+////
+///////////////////////////////////////////
+
+void estopResetTask(void *pvParameters)
+{
+    for (;;)
+    {
+        if (stopSwitchTriggered == 1)
+        {
+            while ((ossm.getAnalogAveragePercent(SPEED_POT_PIN, 50) > 2))
+            {
+                vTaskDelay(1);
+            }
+            stopSwitchTriggered = 0;
+            vTaskResume(motionTask);
+            vTaskResume(getInputTask);
+        }
+        vTaskDelay(100);
+    }
+}
+
+void wifiConnectionTask(void *pvParameters)
+{
+#if INTERNET_CONNECTION_MODE >= 1
+    ossm.wifiConnectOrHotspotBlocking();
+#else
+    Serial.println("Skipping wifi connection task due to INTERNET_CONNECTION_MODE defined in OSSM_Config.h");
+#endif
+}
+
+// Task to read settings from server - only need to check this when in WiFi
+// control mode
+void getUserInputTask(void *pvParameters)
+{
+    bool wifiControlEnable = false;
+    for (;;) // tasks should loop forever and not return - or will throw error in OS
+    {
+        ossm.updateAnalogInputs();
+
+        ossm.speedPercentage > 1 ? ossm.stepper.releaseEmergencyStop() : ossm.stepper.emergencyStop();
+
+#if INTERNET_CONNECTION_MODE >= 1
+        if (digitalRead(WIFI_CONTROL_TOGGLE_PIN) == HIGH) // TODO: check if wifi available and handle gracefully
+        {
+            if (wifiControlEnable == false)
+            {
+                // this is a transition to WiFi, we should tell the server it has control
+                wifiControlEnable = true;
+                if (WiFi.status() != WL_CONNECTED)
+                {
+                    delay(5000);
+                }
+                setInternetControl(wifiControlEnable);
+            }
+            getInternetSettings(); // we load ossm.speedPercentage and ossm.strokePercentage in
+                                   // this routine.
+        }
+        else
+        {
+            if (wifiControlEnable == true)
+            {
+                // this is a transition to local control, we should tell the server it cannot control
+                wifiControlEnable = false;
+                setInternetControl(wifiControlEnable);
+            }
+            // ossm.speedPercentage = ossm.speedPercentage;
+            // ossm.strokePercentage = getAnalogAverage(STROKE_POT_PIN, 50);
+            // ossm.strokePercentage = ossm.getEncoderPercentage();
+        }
+#endif
+
+        // We should scale these values with initialized settings not hard coded
+        // values!
+        if (ossm.speedPercentage > commandDeadzonePercentage)
+        {
+            ossm.stepper.setSpeedInMillimetersPerSecond(ossm.maxSpeedMmPerSecond * ossm.speedPercentage / 100.0);
+            ossm.stepper.setAccelerationInMillimetersPerSecondPerSecond(
+                ossm.maxSpeedMmPerSecond * ossm.speedPercentage * ossm.speedPercentage / ossm.accelerationScaling);
+            // We do not set deceleration value here because setting a low decel when
+            // going from high to low speed causes the motor to travel a long distance
+            // before slowing. We should only change decel at rest
+        }
+        vTaskDelay(50); // let other code run!
+    }
+}
+
+void motionCommandTask(void *pvParameters)
+{
+    for (;;) // tasks should loop forever and not return - or will throw error in
+             // OS
+    {
+        switch (ossm.activeRunMode)
+        {
+            case ossm.simpleMode:
+                ossm.runPenetrate();
+                break;
+
+            case ossm.strokeEngineMode:
+                ossm.runStrokeEngine();
+                break;
+        }
+    }
+}
+
+bool setInternetControl(bool wifiControlEnable)
+{
+#if INTERNET_CONNECTION_MODE >= 3
+    // here we will SEND the WiFi control permission, and current speed and stroke
+    // to the remote server. The cloudfront redirect allows http connection with
+    // bubble backend hosted at app.researchanddesire.com
+
+    String serverNameBubble = !INTERNET_CONNECTION_TEST_SERVER
+                                  ? "http://d2g4f7zewm360.cloudfront.net/ossm-set-control"   // live server
+                                  : "http://d2oq8yqnezqh3r.cloudfront.net/ossm-set-control"; // test server
+
+    // Add values in the document to send to server
+    StaticJsonDocument<200> doc;
+    doc["ossmId"] = ossmId;
+    doc["wifiControlEnabled"] = wifiControlEnable;
+    doc["stroke"] = ossm.strokePercentage;
+    doc["speed"] = ossm.speedPercentage;
+    String requestBody;
+    serializeJson(doc, requestBody);
+
+    // Http request
+    HTTPClient http;
+    http.begin(serverNameBubble);
+    http.addHeader("Content-Type", "application/json");
+    // post and wait for response
+    int httpResponseCode = http.POST(requestBody);
+    String payload = "{}";
+    payload = http.getString();
+    http.end();
+
+    // deserialize JSON
+    StaticJsonDocument<200> bubbleResponse;
+    deserializeJson(bubbleResponse, payload);
+
+    // TODO: handle status response
+    // const char *status = bubbleResponse["status"]; // "success"
+
+    const char *wifiEnabledStr = (wifiControlEnable ? "true" : "false");
+    LogDebugFormatted("Setting Wifi Control: %s\n%s\n%s\n", wifiEnabledStr, requestBody.c_str(), payload.c_str());
+    LogDebugFormatted("HTTP Response code: %d\n", httpResponseCode);
+
+    return true;
+#else
+    Serial.println("Skipping setInternetControl() due to INTERNET_CONNECTION_MODE defined in OSSM_Config.h");
+    return false;
+#endif
+}
+
+bool getInternetSettings()
+{
+#if INTERNET_CONNECTION_MODE >= 3
+    // here we will request speed and stroke settings from the remote server. The
+    // cloudfront redirect allows http connection with bubble backend hosted at
+    // app.researchanddesire.com
+
+    String serverNameBubble = !INTERNET_CONNECTION_TEST_SERVER
+                                  ? "http://d2g4f7zewm360.cloudfront.net/ossm-get-settings"   // live server
+                                  : "http://d2oq8yqnezqh3r.cloudfront.net/ossm-get-settings"; // test server
+
+    // Add values in the document
+    StaticJsonDocument<200> doc;
+    doc["ossmId"] = ossmId;
+    String requestBody;
+    serializeJson(doc, requestBody);
+
+    // Http request
+    HTTPClient http;
+    http.begin(serverNameBubble);
+    http.addHeader("Content-Type", "application/json");
+    // post and wait for response
+    int httpResponseCode = http.POST(requestBody);
+    String payload = "{}";
+    payload = http.getString();
+    http.end();
+
+    // deserialize JSON
+    StaticJsonDocument<200> bubbleResponse;
+    deserializeJson(bubbleResponse, payload);
+
+    // TODO: handle status response
+    // const char *status = bubbleResponse["status"]; // "success"
+    ossm.strokePercentage = bubbleResponse["response"]["stroke"];
+    ossm.speedPercentage = bubbleResponse["response"]["speed"];
+
+    // debug info on the http payload
+    LogDebug(payload);
+    LogDebugFormatted("HTTP Response code: %d\n", httpResponseCode);
+
+    return true;
+#else
+    Serial.println("Skipping getInternetSettings() due to INTERNET_CONNECTION_MODE defined in OSSM_Config.h");
+    return false;
+#endif
+}
+// void setLedRainbow(CRGB leds[])
+// {
+//     // int power = 250;
+
+//     for (int hueShift = 0; hueShift < 350; hueShift++)
+//     {
+//         int gHue = hueShift % 255;
+//         fill_rainbow(leds, NUM_LEDS, gHue, 25);
+//         FastLED.show();
+//         delay(4);
+//     }
+// }

--- a/PlatformIO ESP32 code/OSSM_ESP32/src/Utilities.h
+++ b/PlatformIO ESP32 code/OSSM_ESP32/src/Utilities.h
@@ -11,6 +11,7 @@
 #include <StrokeEngine.h>
 
 #include "FastLED.h" // Used for the LED on the Reference Board (or any other pixel LEDS you may add)
+#include "ModbusClientRTU.h"
 #include "OSSM_Config.h"
 #include "OSSM_PinDef.h"
 #include "OssmUi.h" // Separate file that helps contain the OLED screen functions
@@ -26,6 +27,7 @@
 #define MODE_DEPTH 1
 #define MODE_SENSATION 2
 #define MODE_PATTERN 3
+#define MODE_FORCE 4
 
 class OSSM
 {
@@ -39,7 +41,11 @@ class OSSM
     OssmUi g_ui;
     CRGB ossmleds[NUM_LEDS];
 
-    enum runMode {simpleMode, strokeEngineMode};
+    enum runMode
+    {
+        simpleMode,
+        strokeEngineMode
+    };
     int runModeCount = 2;
 
     runMode activeRunMode = simpleMode;
@@ -65,15 +71,40 @@ class OSSM
     char Id[20];
 
     bool wifiControlActive = false;
-    float speedPercentage = 0;  // percentage 0-100
-    float depthPercentage = 100; // percentage 0-100
-    float strokePercentage = 10; // percentage 0-100
-    float sensationPercentage = 40; // percentage 0-100, maps to sensation -100 - 100, so 40 default = -20 sensation
+    float speedPercentage = 0;      // percentage 0-100
+    float depthPercentage = 100;    // percentage 0-100
+    float strokePercentage = 10;    // percentage 0-100
+    float sensationPercentage = 86; // percentage 0-100, maps to sensation -100 - 100, so 86 default = +72 sensation
+    float forcePercentage = 40;     // percentage 0-100, maps to force 2-12, so default of 40 = 6 force
+
     int strokePattern = 0;
     int strokePatternCount = 0;
-    int changePattern = 0; // -1 = prev, 1 = next
+    int changePattern = 0;   // -1 = prev, 1 = next
     bool modeChanged = true; // initialize encoder state
-    int rightKnobMode = 0; // MODE_STROKE, MODE_DEPTH, MODE_SENSATION, MODE_PATTERN
+    int rightKnobMode = 0;   // MODE_STROKE, MODE_DEPTH, MODE_SENSATION, MODE_PATTERN, MODE_FORCE
+
+#if SERVO_TORQUE_SETTING
+    ModbusClientRTU* MB;
+    uint32_t MB_Token = 1111;
+    bool modbusDetected = false;
+    void setForce(int force);
+    int calculateForce(float forcePercentage);
+    bool setupModbusAndReportState();
+#else
+    bool modbusDetected = false;
+    void setForce(int force)
+    {
+        return;
+    }
+    int calculateForce(float forcePercentage)
+    {
+        return -1;
+    }
+    bool setupModbusAndReportState()
+    {
+        return false;
+    }
+#endif
 
     OSSM()
         : g_encoder(ENCODER_A, ENCODER_B),
@@ -83,8 +114,8 @@ class OSSM
 
     void setup();
 
-    void runPenetrate(); //runs actual penetration motion one cycle
-    void runStrokeEngine(); //runs stroke Engine
+    void runPenetrate();    // runs actual penetration motion one cycle
+    void runStrokeEngine(); // runs stroke Engine
     String getPatternJSON(StrokeEngine Stroker);
     void setRunMode();
 


### PR DESCRIPTION
* Added force control for both stroke engine and the basic mode. It works better in stroke engine, i think because the normal mode yields control to other async tasks and tries to update its position in a different way. Anyway, stroke engine has it as well and its really nice in there... so a partial bonus that i got it somewhat working in basic mode i guess

* added a lot of #defines for turning logging on and off, hopefully it makes deving a bit nicer. im sure theres stuff i missed, but I tried to revamp log messages wherever i saw them being used in code paths i modified

* added levels of internet connectivity so that people who are ~paranoid~ security minded can select how much the OSSM connects to the internet (none, local wifi only, public internet only for updates, and public internet with control-ability)

* various other small changes (or big ones, in the case of my editor refactoring stroke engine to use the projects clang style) 