### PR TITLE
Improved Remote UI Experience

### DIFF
--- a/Software/src/OssmUi/OssmUi.cpp
+++ b/Software/src/OssmUi/OssmUi.cpp
@@ -58,12 +58,34 @@ void OssmUi::UpdateState(const String& mode_label, const int speed_percentage, c
     int speed_height = (64 - 12) * speed_percentage / 100;
     display.drawBox(0, 64 - speed_height, 24, speed_height);
 
+    // Speed gradation
+    display.setColorIndex(2);   // XOR mode
+    display.drawLine(0, 12, 23, 12);    // 100%
+    display.drawLine(0, 25, 6, 25);    // 75%
+    display.drawLine(0, 38, 12, 38);    // 50%
+    display.drawLine(0, 51, 6, 51);    // 25%
+    display.drawLine(0, 63, 23, 63);    // 0%
+
     // draw the encoder position rect
+    display.setColorIndex(1);
     int height = constrain((64 - 12) * encoder_position / 100, 0, 64 - 12);
     display.drawBox(128 - 24, 64 - height, 24, height);
 
+    // Encoder position gradation (this should be obvious, but I want it symetrical!)
+    display.setColorIndex(2);   // XOR mode
+    display.drawLine(128, 12, 128-23, 12);    // 100%
+    display.drawLine(128, 25, 128-6, 25);    // 75%
+    display.drawLine(128, 38, 128-12, 38);    // 50%
+    display.drawLine(128, 51, 128-6, 51);    // 25%
+    display.drawLine(128, 63, 128-23, 63);    // 0%
+
+    display.setColorIndex(1);
     display.setFont(u8g2_font_helvR08_tf);
-    display.drawUTF8(0, 10, "SPEED");
+    if(speed_percentage == 0){
+        display.drawUTF8(0, 10, "STOPPED");
+    } else {
+        display.drawUTF8(0, 10, "SPEED");
+    }
 
     int width = display.getUTF8Width(mode_label.c_str());
     display.drawUTF8(128 - width, 10, mode_label.c_str());

--- a/Software/src/Utilities.cpp
+++ b/Software/src/Utilities.cpp
@@ -141,7 +141,8 @@ float calculateSensation(float sensationPercentage)
     Stroker.setStroke(0.01f * strokePercentage * abs(maxStrokeLengthMm), true);
     Stroker.moveToMax(10 * 3);
     Serial.println(Stroker.getState());
-    //    OssmUi::UpdateMessage(Stroker.getPatternName(strokePattern));
+
+    strokerPatternName = Stroker.getPatternName(strokePattern); // Set the initial stroke engine pattern name
 
     for (;;)
     {
@@ -167,24 +168,33 @@ float calculateSensation(float sensationPercentage)
         {
             Serial.printf("switching mode pre: %i %i\n", rightKnobMode, buttonPressCount);
 
-            if (buttonPressCount > 1)
+            // If we are coming from the pattern selection, apply the new pattern upon switching out of it.
+            // This is to prevent sudden jarring pattern changes while scrolling through them "live".
+            if(rightKnobMode == MODE_PATTERN){
+                Stroker.setPattern(int(strokePattern), false); // Pattern, index must be < Stroker.getNumberOfPattern()
+            }
+
+            
+            if (buttonPressCount > 1)   // Enter pattern-selection mode if the button is pressed more than once
             {
                 rightKnobMode = MODE_PATTERN;
             }
-            else if (strokePattern == 0)
+            else if (strokePattern == 0)    // If the button was only pressed once and we're in the basic stroke engine pattern...
             {
+                // ..clamp the right knob mode so that we bypass the "sensation" mode
                 rightKnobMode += 1;
-                if (rightKnobMode > 1)
+                if (rightKnobMode > MODE_DEPTH)
                 {
-                    rightKnobMode = 0;
+                    rightKnobMode = MODE_STROKE;
                 }
             }
             else
             {
+                // Otherwise allow us to select the sensation control mode
                 rightKnobMode += 1;
-                if (rightKnobMode > 2)
+                if (rightKnobMode > MODE_SENSATION)
                 {
-                    rightKnobMode = 0;
+                    rightKnobMode = MODE_STROKE;
                 }
             }
 
@@ -233,8 +243,7 @@ float calculateSensation(float sensationPercentage)
 
             Serial.println(Stroker.getPatternName(strokePattern));
 
-            Stroker.setPattern(int(strokePattern), false); // Pattern, index must be < Stroker.getNumberOfPattern()
-            //            OssmUi::UpdateMessage(Stroker.getPatternName(strokePattern));
+            strokerPatternName = Stroker.getPatternName(strokePattern); // Update the stroke pattern name (used by the UI)
 
             modeChanged = true;
         }

--- a/Software/src/Utilities.h
+++ b/Software/src/Utilities.h
@@ -46,7 +46,7 @@ class OSSM
     };
     int runModeCount = 2;
 
-    runMode activeRunMode = simpleMode;
+    runMode activeRunMode = strokeEngineMode;
     float maxSpeedMmPerSecond = hardcode_maxSpeedMmPerSecond;
     float motorStepPerRevolution = hardcode_motorStepPerRevolution;
     float pulleyToothCount = hardcode_pulleyToothCount;

--- a/Software/src/Utilities.h
+++ b/Software/src/Utilities.h
@@ -81,6 +81,8 @@ class OSSM
     bool modeChanged = true; // initialize encoder state
     int rightKnobMode = 0;   // MODE_STROKE, MODE_DEPTH, MODE_SENSATION, MODE_PATTERN
 
+    String strokerPatternName = "Default";  // The name of the current stroke engine pattern
+
     OSSM()
         : g_encoder(ENCODER_A, ENCODER_B),
           g_ui() // this just creates the objects with parameters

--- a/Software/src/main.cpp
+++ b/Software/src/main.cpp
@@ -142,7 +142,7 @@ void loop()
                                 static_cast<int>(ossm.sensationPercentage + 0.5f));
             break;
         case MODE_PATTERN:
-            OssmUi::UpdateState("PATTRN", static_cast<int>(ossm.speedPercentage),
+            OssmUi::UpdateState(ossm.strokerPatternName, static_cast<int>(ossm.speedPercentage),
                                 ossm.strokePattern * 100 / (ossm.strokePatternCount - 1));
             break;
     }

--- a/Software/src/main.cpp
+++ b/Software/src/main.cpp
@@ -91,7 +91,7 @@ void setup()
 
     ossm.findHome();
 
-    ossm.setRunMode();
+    //ossm.setRunMode();
 
     // Kick off the http and motion tasks - they begin executing as soon as they
     // are created here! Do not change the priority of the task, or do so with


### PR DESCRIPTION
### Description:

This pull request contains a few minor quality of life tweaks to the OSSM remote's interface.

- Added gradation to the left potentiometer position gauge and right encoder position gauges
- Made the "SPEED" text over the left box say "STOPPED" when the speed is set to 0
- The OSSM will now boot straight into stroke engine mode
- When entering pattern selection mode (double-click encoder button), the name of the pattern is now displayed
- The stroke engine pattern is only changed once you exit out of the pattern selection mode, preventing sudden pattern changes as you're scrolling through them