### PR TITLE
Fix links in README when rendered to github pages and other fixes/cleanup

### DIFF
--- a/Documentation/Safety and Design Guide.md
+++ b/Documentation/Safety and Design Guide.md
@@ -1,4 +1,4 @@
-**Safety and designing for the OSSM**
+# Safety and designing for the OSSM
 
 One of the great things about the OSSM is it can be modified by anyone.  This means if you are going to use, modify or contribute to the OSSM project you need to be aware of the risks and potential hazards.  After all, an OSSM is poking around in some very intimate and soft places.  There are moving belts and motors that have a surprising amount of force all of which can hurt people.  
 
@@ -10,27 +10,26 @@ Our analysis identifies three areas of hazard; design, build and use which neatl
 
 ***Users*** fall into two subgroups and you can be both at once.  Operators and the receptive user who is having all the fun.  Good design and a quality build can provide some protection. But keep in mind, a misused OSSM can create hazards that cannot be mitigated by design.  
 
-**Guidance for designers**
+## Guidance for designers
 
-  - Think about any new hazards that your design may introduce.  Some ideas cannot be made safe, but other risks can be managed with careful thought. 
-  - Inclusive design is often safer design.   Designing for people that are visually, physically or cognitively impaired is hard but there are many benefits.
-  - FDM/3D printed materials have some qualities you need to be aware of.  Layer orientation, material choice all can have a positive (or negative) impact on safety.
-  - For safety critical cases be aware of the limitations of software.  Programming for safety is harder than it looks and there is a considerable body of knowledge devoted to it.  If you can find an alternate hazard mitigation such as a power switch that will be more reliable than a software interrupt.  
-  - Don’t expect users and builders to “do the right thing”.  A designer is often best placed to understand the potential issues.  A builder may not identify risks and users are often distracted when using an OSSM. 
+- Think about any new hazards that your design may introduce.  Some ideas cannot be made safe, but other risks can be managed with careful thought.
+- Inclusive design is often safer design.   Designing for people that are visually, physically or cognitively impaired is hard but there are many benefits.
+- FDM/3D printed materials have some qualities you need to be aware of.  Layer orientation, material choice all can have a positive (or negative) impact on safety.
+- For safety critical cases be aware of the limitations of software.  Programming for safety is harder than it looks and there is a considerable body of knowledge devoted to it.  If you can find an alternate hazard mitigation such as a power switch that will be more reliable than a software interrupt.  
+- Don’t expect users and builders to “do the right thing”.  A designer is often best placed to understand the potential issues.  A builder may not identify risks and users are often distracted when using an OSSM.
 
-**Guidance for builders**
+## Guidance for builders
 
--	Get to know your 3D printer and filament.  For critical parts print with thicker walls, larger layer heights and hotter temperatures than normal to maximize strength.  Resin printers do not typically create strong enough prints to be used safely.
--	Think about finishing and sharp edges.  An OSSM is frequently used with minimal clothing and users are often distracted.
--	Try to avoid relying on the user of the OSSM to "do the right thing” and work around build deficiencies or missing parts such as covers.  
+- Get to know your 3D printer and filament.  For critical parts print with thicker walls, larger layer heights and hotter temperatures than normal to maximize strength.  Resin printers do not typically create strong enough prints to be used safely.
+- Think about finishing and sharp edges.  An OSSM is frequently used with minimal clothing and users are often distracted.
+- Try to avoid relying on the user of the OSSM to "do the right thing” and work around build deficiencies or missing parts such as covers.  
 
-**Guidance for users**
+## Guidance for users
 
--	Understand the risks of using an OSSM.
--	Use appropriate toys.  
--	Take frequent breaks.
--	Perform an inspection prior to use.  Don’t operate an OSSM with missing or broken parts.
--	Don’t operate an OSSM while suffering temporary cognitive impairment.
--	Think about over penetration risks.  Being restrained and unable to move away from the machine greatly increases risk and chance of injury.
--	Lube, lube, lube  
-
+- Understand the risks of using an OSSM.
+- Use appropriate toys.  
+- Take frequent breaks.
+- Perform an inspection prior to use.  Don’t operate an OSSM with missing or broken parts.
+- Don’t operate an OSSM while suffering temporary cognitive impairment.
+- Think about over penetration risks.  Being restrained and unable to move away from the machine greatly increases risk and chance of injury.
+- Lube, lube, lube  

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,85 +1,105 @@
-### Q: What is OSSM? 
+# Frequently Asked Questions
 
-A: An OSSM is compact sex machine that can be customised to suit you.  Based around a NEMA23 pattern for electric motors it can be driven by stepper or best of all servo motors it uses a combination of 3D printed and off the shelf parts. 
+### Q: What is OSSM?
 
-### Q: Why go to all this trouble?  Why don't you just buy a ready made machine? 
+A: An OSSM is compact sex machine that can be customised to suit you.  Based around a NEMA23 pattern for electric motors it can be driven by stepper or best of all servo motors it uses a combination of 3D printed and off the shelf parts.
 
-A: The OSSM is open you are not tied to a specific company and it does a lot more than equivalently priced machines.  Best of all you can fully control the stroke speed and most importantly depth.  You can make patterns or even your own control software.  Maybe you want to add a stroker rather than a dildo, you can modifiy it to do that.  Not enough power? You can use a bigger motor up to a certain point. 
+### Q: Why go to all this trouble?  Why don't you just buy a ready made machine?
 
-### Q: What parts do I need? 
+A: The OSSM is open you are not tied to a specific company and it does a lot more than equivalently priced machines.  Best of all you can fully control the stroke speed and most importantly depth.  You can make patterns or even your own control software.  Maybe you want to add a stroker rather than a dildo, you can modifiy it to do that.  Not enough power? You can use a bigger motor up to a certain point.
 
-A: Head over to https://github.com/KinkyMakers/OSSM-hardware/tree/master - the BOM is in the ReadMe
+### Q: What parts do I need?
+
+A: Head over to [the README](./#bill-of-materials) - the BOM is maintained there.
   
 ### Q: I've been reading about motors and now I'm really confused
   
 A: While you can theoretically use any Nema23 mount motor.  There are motors that work and some that work better.  Stepper motors are cheaper and noiser so the community recommends closed loop servo motors.  These are more efficient and more importantly easier to program.  
 
-### Q:  What strength of  motor do I need? 
+### Q:  What strength of motor do I need?
   
 A: That depends on a couple of factors.  
+
 - Vaginal or Anal use
 - Size of toys
 - Anticipated Speed
   
 We don't have a lot of recorded data [Please help us with this!] however the general suggeestions are;
+
 - **100w** IHSV57 Servo : Vaginal usage with medium size toys and Anal usage with smaller toys (10 lbs force)
 - **140W** IHSV57 Servo : Vaginal usage with larger toys, Anal use with medium size toys (15 lbs force)
 - **180w** IHSV57 servo works with a wide range of toys for vaginal or anal play, and really packs a punch (20 lbs force). However if you like seriously heavy fantasy dildos you might want to consider building a Squooter [see the discord] that uses and even a larger motor mount; the NEMA34 which has even more powerful motors.
 
-A build with a servo motor will have a flat torque curve across the speed range. That's to say - it will push just as hard at the slow speeds as well as the fast. 
-  With a stepper, the most force will be at the slower speeds and the top speed of a stepper is much less than the servo we've chosen to work with. 
+A build with a servo motor will have a flat torque curve across the speed range. That's to say - it will push just as hard at the slow speeds as well as the fast.
+  With a stepper, the most force will be at the slower speeds and the top speed of a stepper is much less than the servo we've chosen to work with.
   
-### Q: Hold on, why does anal play need more powerful motors? 
+### Q: Hold on, why does anal play need more powerful motors?
+
 A: Butts have big powerful muscles! It's common for people to bear down, or clench when things are feeling really good. Also it can be pretty fun shoving big objects in there! It can take a big motor to handle a big toy in a poweful butt.
 
-### Q: What sized 3D printer do I need? 
-A: The minimum bed size is 105mm x 105mm for the largest single piece. Approximately 125mm of height is required for the shorter vac-u-lock compatible adapter, the plate is significantly shorter. 
+### Q: What sized 3D printer do I need?
+
+A: The minimum bed size is 105mm x 105mm for the largest single piece. Approximately 125mm of height is required for the shorter vac-u-lock compatible adapter, the plate is significantly shorter.
 
 ### Q: What print material is best?
+
 A: All of our testing has been with simple PLA, however if you do print it in an interesting material make sure to share it to the discord!
 
-### Q: What is the infill percentage? 
-A: 30% has been found to work just fine with PLA for non flexible parts 
+### Q: What is the infill percentage?
+
+A: 30% has been found to work just fine with PLA for non flexible parts
 
 ### Q: How thick are the walls and top?
-A: Recommend at least 3mm for non flexible parts. 
+
+A: Recommend at least 3mm for non flexible parts.
 
 ### Q: What are these flexible parts and how should I print them?
-A: There are mounting solutions that use clamps for the OSSM these need some flexiblity.  For these parts thinner walls 2mm, lower infill percentages and a gyroid pattern. 
 
-### Q: How do I mount toys onto the OSSM? 
+A: There are mounting solutions that use clamps for the OSSM these need some flexiblity.  For these parts thinner walls 2mm, lower infill percentages and a gyroid pattern.
+
+### Q: How do I mount toys onto the OSSM?
+
 A: Aside from the motor this is second decision.  There is a vacc-u-lock compatible mount the double double and a plate mount for suction cup toys that has some points to tie a dildo down The OSSM Platten
 
 ### Q: What to I mount the machine on?  
-A: Well there are a few designs available.  THere are standard pipe mounts for US/Canadian along with 80/20 rails that can be used like a construction set.  There are even manfrotto boom compatible adaptors.  It is really limited by you imagination. 
 
-### Q: How do I control my OSSM 
+A: Well there are a few designs available.  THere are standard pipe mounts for US/Canadian along with 80/20 rails that can be used like a construction set.  There are even manfrotto boom compatible adaptors.  It is really limited by you imagination.
+
+### Q: How do I control my OSSM
+
 A: It depends on how you are going to use it.  Basic OSSM control is via the wired remote and a more advanced remote is available from community members (M5 Remote).  If you want something specific you can create your own that is the great thing about open source hardware.
 
 ### Q: I heard somewhere you can "control via a web page?"  Can I get people to control my OSSM over the internet?
+
 A: As of August 2023 you cannot control an OSSM over the internet.  In the past R&D offered a web page that allowed very basic control with speed and depth settings over wifi.  
 
 ### Q: X-Toy and funscript support.  Where is it?  
-A: As of August 2023 there is a highly experimental X-toy firmware forked from an earlier version that requires endstops.  This code has significant issue and is not considered to be safe for use on humans. There are frequent pauses, it loses track of where it is and has a tendency to randomly extend to maximum depth. Development of an X-Toys firmware is happening but it is complicated.   
+
+A: As of August 2023 there is a highly experimental X-toy firmware forked from an earlier version that requires endstops.  This code has significant issue and is not considered to be safe for use on humans. There are frequent pauses, it loses track of where it is and has a tendency to randomly extend to maximum depth. Development of an X-Toys firmware is happening but it is complicated.
 
 ### Q: Why is X-Toys/Funscripts/ButtplugIO so difficult?
+
 A: Things are a lot more complicated once you dig down into them.
 
 - The motion core does not yet support position streaming. This is in development and requires a complete redesign of the safety architecture as you don't want to accidentally stab yourself.
 - From the experimental software we learnt that the latency margin is really thin, Bluetooth especially struggles here. This will be a challenge to overcome.
 - The data models of both xtoys and Buttplug.io do not support complex data models as it would be required for OSSM out of the box. As scaling to the full length of OSSM is just not an option. There might be a workaround by emulating an other toy. But you won't be able to control all aspects of OSSM through this.
 
-### Q: There is an OSSM reference board do I have to buy it to make an OSSM? 
+### Q: There is an OSSM reference board do I have to buy it to make an OSSM?
+
 A: No you don't but it does make building an OSSM a lot easier and stops you having to solder anything.  
 
 ### Q: Powersupplies what size do I need?
+
 A: That is linked to the size of motor.  The higher the wattage of motor the larger the powersupply you need.  For safety use a desktop power supply that is ideally double insulated. Power supplies from Mouser/Digikey/Conrad/RS etc are all typically more expensive than "no brand supplies" you get from AliExpress/eBay/Amazon. Experience has been mixed with unbranded supplies with occasional quality and longer term stability issues.  
 
 - 100w JMC we currently suggest a 4A 24V Supply
 - 140w /180w JMC we currently suggest a 6A 24V
 
 ### Q: How long should the H-rail be?
+
 A: It is really up to you but a 350mm rail will give approximately 195mm of depth.  
 
 ### Q: What is the size of the 24mm Thread for the End Effector?
+
 A: It is a M24x3 (this is the size on the machine, do a test print for your new End Effector, you may have to upsize by 3-5%)

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ machine.
 
 ## Getting Started
 
-### <p align="center">[Read the Frequently Asked Questions](FAQ.md)</p>
+### [Read the Frequently Asked Questions](FAQ.md)
 
 There are a few hardware flavours to choose from, we've included community modified versions in case that fits your use
 case better!
 
-### <p align="center">[Build Instructions](Documentation/Assembly%20Instructions.pdf)</p>
+### [Build Instructions](Documentation/Assembly%20Instructions.pdf)
 
-### <p align="center">[Build Videos]("https://youtube.com/playlist?list=PLzSK7OAu3KNQsFo6WJGT8P28lfkD3xpps")</p>
+### [Build Videos]("https://youtube.com/playlist?list=PLzSK7OAu3KNQsFo6WJGT8P28lfkD3xpps")
 
 [Join our Discord](https://discord.gg/MmpT9xE) to be part of the discussion and get help with your build. We have a huge community of
 makers!

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ learning how mechanics, electronics, physics and computing are involved in your 
 Please note that this is a _work in progress_ and we have attempted to keep compatibility with the current BOM going
 forward, but it's not guaranteed.
 
-*Our Primary design goals* are to make a machine that is compact, quiet, of moderate cost, 3D printable (no
+_Our Primary design goals_ are to make a machine that is compact, quiet, of moderate cost, 3D printable (no
 cutting/machining required), flexible, highly performant, with easily sourced components, and doesn't look like a giant
 machine.
 <p align="center">
@@ -19,18 +19,17 @@ machine.
 
 ## Getting Started
 
-<h3><p align="center"><a href="FAQ.md">Read the Frequently Asked Questions</a></p></h3>
+### <p align="center">[Read the Frequently Asked Questions](FAQ.md)</p>
 
 There are a few hardware flavours to choose from, we've included community modified versions in case that fits your use
 case better!
 
-<h3><p align="center"><a href="https://github.com/KinkyMakers/OSSM-hardware/blob/master/Documentation/Assembly%20Instructions.pdf">
-Build Instructions</a></p></h3>
-<h3><p align="center"><a href="https://youtube.com/playlist?list=PLzSK7OAu3KNQsFo6WJGT8P28lfkD3xpps">Build
-Videos</a></p></h3>
+### <p align="center">[Build Instructions](Documentation/Assembly%20Instructions.pdf)</p>
 
-Join our Discord to be part of the discussion and get help with your build. We have a huge community of
-makers! https://discord.gg/MmpT9xE
+### <p align="center">[Build Videos]("https://youtube.com/playlist?list=PLzSK7OAu3KNQsFo6WJGT8P28lfkD3xpps")</p>
+
+[Join our Discord](https://discord.gg/MmpT9xE) to be part of the discussion and get help with your build. We have a huge community of
+makers!
 
 <p align="center">
 <img width="750" alt="image" src="https://github.com/KinkyMakers/OSSM-hardware/assets/43324815/a756a8d5-c075-4e86-8206-b553a0b77127">
@@ -39,13 +38,13 @@ makers! https://discord.gg/MmpT9xE
 ### Software
 
 The software is available in this github repository. It is written and compiled utilizing PlatformIO on Visual Studio
-Code. <a href="OSSM PlatformIO Readme.md">Reference for working with the code in PlatformIO here</a>
+Code. [Reference for working with the code in PlatformIO here](OSSM PlatformIO Readme.md)
 
 We recommend using
 the [Research and Desire Reference Board](https://shop.researchanddesire.com/products/ossm-reference-board) as Do It
 Yourself by someone without extensive electronics knowledge creates a lot of support overhead. This code is still
 arduino IDE compatible but offers many times better performance. Web based control is coming soon. A proof of concept
-can be found at https://app.researchanddesire.com/ossm, however modifications need to be made in order to use this proof
+can be found at [https://app.researchanddesire.com/ossm](https://app.researchanddesire.com/ossm), however modifications need to be made in order to use this proof
 of concept web control.
 
 ### Eagle PCB
@@ -66,7 +65,7 @@ silent operation and very high performance.
 We have a new stand design you can check out on onshape!
 [OnShape link](https://cad.onshape.com/documents/d520ea9a8cadb4ae8681f59b/w/00b211a6fa3b76c59ef28f4e/e/5f2c80d9d9c2433a7be7f789)
 
-![image](https://github.com/KinkyMakers/OSSM-hardware/assets/12459679/fa8a99c4-935e-4774-9f97-a4f88e453722)
+![OSSM on mounting solution](https://github.com/KinkyMakers/OSSM-hardware/assets/12459679/fa8a99c4-935e-4774-9f97-a4f88e453722)
 
 ### Safety
 
@@ -78,51 +77,50 @@ information.
 While using the OSSM we can suggest the following hierarchy of safety, however it is up to you and your build to decide
 what risks exist and how to mitigate them.
 
-- A) Have ability to move away
-- B) Have ability to remove the power
-- C) If you are in bondage, safety is responsibility of the Top
+1. Have ability to move away
+2. Have ability to remove the power
+3. If you are in bondage, safety is responsibility of the Top
 
 ## Bill Of Materials
 
 We are calling this the reference build, when deviating from it please check compatability with existing Bill Of
 Materials (BOM)
 
-1) **[3D Printed Parts](Hardware/OSSM%20Printed%20Parts)**
-    - This has recently had significant changes
-    - [Make sure to choose one of the options for the toy adapters](Hardware/OSSM%20Printed%20Parts/end%20effector%20options)
-    - There are several mounting options available, the most popular being
-      the [Ulanzi Ball head mount](https://github.com/KinkyMakers/OSSM-hardware/tree/master/Hardware/OSSM%20Mounting) or
-      the [Shicks mount](https://github.com/KinkyMakers/OSSM-hardware/tree/master/Hardware/OSSM%20Mounting/Shicks%204040%20mount)
-    - Thank you @Elims for
-      the [belt tensioner design](https://media.discordapp.net/attachments/756320102919700607/858110808281317396/unknown.png) ( https://github.com/theelims/FuckIO )
+1. **[3D Printed Parts](Hardware/OSSM%20Printed%20Parts)**
+   - This has recently had significant changes
+   - [Make sure to choose one of the options for the toy adapters](Hardware/OSSM%20Printed%20Parts/end%20effector%20options)
+   - There are several mounting options available, the most popular being
+   the [Ulanzi Ball head mount](Hardware/OSSM%20Mounting) or
+   the [Shicks mount](Hardware/OSSM%20Mounting/Shicks%204040%20mount)
+   - Thank you @Elims for
+   the [belt tensioner design]( https://github.com/theelims )
 
-2) **IHSV57 NEMA23 Servo with 8mm shaft** :
-    - *Avoid the StepperOnline version*
-    - Make sure you get something with **8mm** shaft.
-    - There are *3* sizes of this motor:  
-      100W = [iHSV57-30-**10**](https://www.aliexpress.com/w/wholesale-iHSV57%2525252d30%2525252d10.html)
+2. **IHSV57 NEMA23 Servo with 8mm shaft** :
+   - *Avoid the StepperOnline version*
+   - Make sure you get something with **8mm** shaft.
+   - There are *3* sizes of this motor:  
+     100W = [iHSV57-30-**10**](https://www.aliexpress.com/w/wholesale-iHSV57%2525252d30%2525252d10.html)
 
-      140W = [iHSV57-30-**14**](https://www.aliexpress.com/w/wholesale-iHSV57%2525252d30%2525252d14.html)
+     140W = [iHSV57-30-**14**](https://www.aliexpress.com/w/wholesale-iHSV57%2525252d30%2525252d14.html)
 
-      180W = [iHSV57-30-**18**](https://www.aliexpress.com/w/wholesale-iHSV57%2525252d30%2525252d18.html)
+     180W = [iHSV57-30-**18**](https://www.aliexpress.com/w/wholesale-iHSV57%2525252d30%2525252d18.html)
 
-    - We recommend motors with firmware version 6 (shown as `V60x`). Pay attention to
-      this, [the firmware version is printed on the label on the side.](https://user-images.githubusercontent.com/131713378/234460307-1c29c18b-3bb5-4ac9-b66f-0dea9df0acac.png)
-      You cannot update the motor firmware. version 5 will work, but it is not as feature rich for potential new
+     - We recommend motors with firmware version 6 (shown as `V60x`). Pay attention to
+     this, [the firmware version is printed on the label on the side.](https://user-images.githubusercontent.com/131713378/234460307-1c29c18b-3bb5-4ac9-b66f-0dea9df0acac.png)
+     You cannot update the motor firmware. version 5 will work, but it is not as feature rich for potential new
       features.
-    - Search around for the best deal for you - we reccommend searching "ihsv57" on Aliexpress.com and choosing the -10
-      -14 or -18. Some example listings:
+     - Search around for the best deal for you - we reccommend searching "ihsv57" on Aliexpress.com and choosing the -10 -14 or -18. Some example listings:
 
-      [AliExpress - US](https://www.aliexpress.us/item/2251832528412325.html)
+       [AliExpress - US](https://www.aliexpress.us/item/2251832528412325.html)
 
-      [AliExpress - CA & AU](https://www.aliexpress.us/item/32714727077.html)
+       [AliExpress - CA & AU](https://www.aliexpress.us/item/32714727077.html)
 
-    - For details on picking the right motor for your use case - check
+     - For details on picking the right motor for your use case - check
       this [FAQ](https://github.com/KinkyMakers/OSSM-hardware/blob/master/FAQ.md#q--what-strength-of--motor-do-i-need)
-    - If you are using the 140W or 180W version it is recommended to use a 10mm wide belt and pulley (see the next two
-      items)
+     - If you are using the 140W or 180W version it is recommended to use a  10mm wide belt and pulley (see the next two
+     items)
 
-3) **GT2 Pulley 8mm Bore 20 Tooth, 10mm width** :
+3. **GT2 Pulley 8mm Bore 20 Tooth, 10mm width** :
 
    [Amazon - CA](https://www.amazon.ca/Timing-Pulley-8mm-bore-10mm-belt-20-Tooth/dp/B09L7D7HHT)
 
@@ -130,7 +128,7 @@ Materials (BOM)
 
    [Banggood - AU](https://au.banggood.com/5MM-or-6_35MM-or-8MM-Bore-20TeethGT2-Alumium-Timing-Pulley-For-Width-10mm-GT2-Belt-p-1106314.html)
 
-4) **GT2 Timing Belt - 10mm width** :    '
+4. **GT2 Timing Belt - 10mm width** :
 
    [Amazon - CA](www.amazon.ca/Timing-Meters-Creality-Anycubic-Printer/dp/B097T4DFM6)
 
@@ -138,16 +136,16 @@ Materials (BOM)
 
    [Amazon - AU]()
 
-    - Your desired stroke length plus about 200mm should be your minimum order length
+   - Your desired stroke length plus about 200mm should be your minimum order length
 
-5) **Bearings** MR115-2RS 5x11x4mm :   
+5. **Bearings** MR115-2RS 5x11x4mm :
    [Amazon - CA](https://www.amazon.ca/gp/product/B07CVBW44R)
 
    [Amazon - US](https://www.amazon.com/Miniature-Bearings-MR115-2RS-Double-Shielded-5x11x4mm/dp/B08PFT72RQ)
 
    [Aliexpress - AU](https://www.aliexpress.us/item/2251832628223170.html)
 
-6) **MGN12H Rail and bearing** :
+6. **MGN12H Rail and bearing** :
 
    [Amazon - CA](https://www.amazon.ca/MGN12H-Stainless-Carriage-Precision-Machine/dp/B09TWKWCZR)
 
@@ -155,50 +153,45 @@ Materials (BOM)
 
    [Aliexpress - AU](https://www.aliexpress.com/item/32840113910.html)
 
-    - Minimum 250mm in length, suggested 350mm
-    - Rail length = desired stroke + 180mm
-    - Must be MGN12**H** rail
+   - Minimum 250mm in length, suggested 350mm
+   - Rail length = desired stroke + 180mm
+   - Must be MGN12**H** rail
 
-7) **Power Supply** : 24 volt 4-5 amp w/ 2.1mm barrel DC plug
+7. **Power Supply**: 24 volt 4-5 amp w/ 2.1mm barrel DC plug
 
-    - Larger motors generally need more power!
-      180W -> 24V 5A suggested minimum
-      140W -> 24V 4A suggested minimum
-      100W -> 24V 4A suggested minimum
+   - Larger motors generally need more power!  
+     180W -> 24V 5A suggested minimum  
+     140W -> 24V 4A suggested minimum  
+     100W -> 24V 4A suggested minimum
 
-    - See the FAQ for more details about power supply sizing based on real world experience of OSSM users.
-    - The OSSM will work with small power supplies, but will be limited on maximum force.
-    - Ensure the power supply is fully enclosed and shielded to avoid cross talk from electromagnetic interference (like
-      a laptop power supply).
-    - Ensure the power supply has the correct approvals for your location - This really helps ensure performance as
-      well! (UL, CE, etc.)
-    - It is strongly recommended that you purchase a good quality PSU such as a Meanwell.
+   - See the FAQ for more details about power supply sizing based on real world experience of OSSM users.
+   - The OSSM will work with small power supplies, but will be limited on maximum force.
+   - Ensure the power supply is fully enclosed and shielded to avoid cross talk from electromagnetic interference (like a laptop power supply).
+   - Ensure the power supply has the correct approvals for your location - This really helps ensure performance as well! (UL, CE, etc.)
+   - It is strongly recommended that you purchase a good quality PSU such as a Meanwell.
 
-8) **Metric Hex Cap Screws** :  
+8. **Metric Hex Cap Screws** :  
    [Amazon - CA & US](https://www.amazon.ca/Comdox-500pcs-Socket-Screws-Assortment/dp/B06XQLTLHP)
 
    [Amazon - AU](https://www.amazon.com.au/VIGRUE-Stainless-Hexagon-Washers-Assortment/dp/B08CK9Y971) (this is a little
    expensive, we are looking for a cheaper alternative)
 
-    - A kit like the ones above will provide what's needed:
-    - 4x m5x20
-    - 1x m5x12 (can also use m5x20)
-    - 10x m3x8
-    - 2x m3x16
-    - 8x m5 nuts
-    - 8x m3 nuts
+   - A kit like the ones above will provide what's needed:
+   - 4x m5x20
+   - 1x m5x12 (can also use m5x20)
+   - 10x m3x8
+   - 2x m3x16
+   - 8x m5 nuts
+   - 8x m3 nuts
 
-9) **ESP32 Development Board**
-
-    - [An official OSSM reference PCB](https://research-and-desire.myshopify.com/collections/all/products/ossm-reference-board)
-    - We do not currently have a best suggestion if you are not using a reference board, most generic development boards
-      are the same
-    - We have found that the 3.3v boards may miss steps at high speed, so please use a level shifter as well.
-    - To start working on the project, something like this [Adafruit board](https://www.adafruit.com/product/3405) is an
-      excellent place to start.
-    - Accessories required for prototyping
-      include [Breadboard](https://www.amazon.ca/Breadboard-Solderless-Prototype-Distribution-Connecting/dp/B01EV6LJ7G/ref=sr_1_5?dchild=1&keywords=breadboard&qid=1627823170&sr=8-5)
-      and [Dupont Jumpers](https://www.amazon.ca/120pcs-Multicolored-Breadboard-Arduino-raspberry/dp/B01LZF1ZSZ/ref=sr_1_5?dchild=1&keywords=dupont+jumper&qid=1627823220&sr=8-5)
+9. **ESP32 Development Board**
+   - [An official OSSM reference PCB](https://research-and-desire.myshopify.com/collections/all/products/ossm-reference-board)
+   - We do not currently have a best suggestion if you are not using a reference board, most generic development boards are the same
+   - We have found that the 3.3v boards may miss steps at high speed, so please use a level shifter as well.
+   - To start working on the project, something like this [Adafruit board](https://www.adafruit.com/product/3405) is an excellent place to start.
+   - Accessories required for prototyping
+     include [Breadboard](https://www.amazon.ca/Breadboard-Solderless-Prototype-Distribution-Connecting/dp/B01EV6LJ7G/ref=sr_1_5?dchild=1&keywords=breadboard&qid=1627823170&sr=8-5)
+     and [Dupont Jumpers](https://www.amazon.ca/120pcs-Multicolored-Breadboard-Arduino-raspberry/dp/B01LZF1ZSZ/ref=sr_1_5?dchild=1&keywords=dupont+jumper&qid=1627823220&sr=8-5)
 
 ### Octopart Links for ease of ordering and tracking
 
@@ -209,17 +202,17 @@ vendors but it still makes for a convenient list.
 
 ## Official OSSM Wiring
 
-![image](https://user-images.githubusercontent.com/43324815/150361448-80e9fdaf-4a8c-4054-a920-6eab9aa68678.png)
+![OSSM reference board front](https://user-images.githubusercontent.com/43324815/150361448-80e9fdaf-4a8c-4054-a920-6eab9aa68678.png)
 The above image is of a version 1 reference board.
 
 ### OSSM PCB Connections
 
-![image](https://user-images.githubusercontent.com/43324815/150355658-2ab2c53f-8da0-41ce-ad61-cfe9965b9ab2.png)
+![OSSM PCB connection diagram](https://user-images.githubusercontent.com/43324815/150355658-2ab2c53f-8da0-41ce-ad61-cfe9965b9ab2.png)
 
 ### GPIO Layout
 
-![OSSM pinout](https://user-images.githubusercontent.com/12459679/152600401-80b986ea-6f5b-480d-ba74-5b5001079c1b.png)
-![JST Header](https://user-images.githubusercontent.com/12459679/226189433-db28dfc6-22ac-4fdb-8b45-afe0c3fa9a7b.png)
+![OSSM pinout diagram](https://user-images.githubusercontent.com/12459679/152600401-80b986ea-6f5b-480d-ba74-5b5001079c1b.png)
+![JST Header location with pin labels](https://user-images.githubusercontent.com/12459679/226189433-db28dfc6-22ac-4fdb-8b45-afe0c3fa9a7b.png)
 
 ## Non-Official OSSM Wiring
 
@@ -236,5 +229,4 @@ be different
 
 ### Stepper Wiring
 
-![wiring notes](https://github.com/KinkyMakers/OSSM-hardware/blob/44ab7a5deafa7dd3d66d521bb368959db542c164/Hardware/PCB/wiring%20notes%20800.png)
-
+![wiring notes](Hardware/PCB%20Files/Archive/Alpha%20PCB%20-%20never%20widely%20used/wiring%20notes%20800.png)


### PR DESCRIPTION
### Description:

Resolve Issue #109 

I have deployed the edited code [here](https://ortho-max.github.io/OSSM-hardware/) so changes can be previewed live ([original](https://kinkymakers.github.io/OSSM-hardware/) for comparison).

- Convert html links to markdown so they render back into html properly when being deployed to github-pages
  - This is needed so that a link to FAQ.md is detected and changed to link to the generated FAQ.html
- Fix list indenting to fit github markdown formatting rules
  - This one was a bit more odd - it seems that github pages uses a different markdown interpreter that takes a 4 space indent (beyond the level of the list) as a code block, which is why random parts of the BOM are currently showing as code blocks. This is now fixed.
  - I have kept indenting to 2 space tab stops to make editing easier.
- Add meaningful alt text to image links (where link was markdown)
- Change as much html to markdown as possible
  - Some html is used to centre items on the page and to constrain width of images this is not something markdown can do.
  - Image sizes should be set by uploading an image of the correct dimensions. This is out of scope of this PR.
- Tidy up markdown formatting
  - Blank lines around headers and lists
  - Remove trailing whitespace (except where needed)
  - Use _ for italics
- Add heading to FAQ

There may be a couple of conflicts between this and my other PR, but they will be easily resolved.