### PR TITLE
Initial work for Advanced Settings menu. Data write/read missing.

### DIFF
--- a/Software/src/constants/Config.h
+++ b/Software/src/constants/Config.h
@@ -14,6 +14,11 @@ namespace Config {
     */
     namespace Driver {
 
+        // TODO: Configure values using saved data retrieved from EEPROM (or similar)
+
+        // Whether the motor should set home inverted from default
+        constexpr bool invert = false;
+
         // Top linear speed of the device.
         constexpr float maxSpeedMmPerSecond = 900.0f;
 

--- a/Software/src/constants/Menu.h
+++ b/Software/src/constants/Menu.h
@@ -11,6 +11,7 @@ enum Menu {
     UpdateOSSM,
     WiFiSetup,
     Help,
+    AdvancedConfiguration,
     Restart,
     NUM_OPTIONS
 };
@@ -21,6 +22,7 @@ static String menuStrings[Menu::NUM_OPTIONS] = {
     UserConfig::language.Update,
     UserConfig::language.WiFiSetup,
     UserConfig::language.GetHelp,
+    UserConfig::language.AdvancedConfiguration,
     UserConfig::language.Restart};
 
 #endif  // OSSM_SOFTWARE_MENU_H

--- a/Software/src/constants/UserConfig.h
+++ b/Software/src/constants/UserConfig.h
@@ -2,7 +2,7 @@
 #define OSSM_SOFTWARE_USERCONFIG_H
 
 #include "constants/copy/en-us.h"
-#include "constants/copy/fr.h"
+//#include "constants/copy/fr.h" // Commented to help with memory issues
 
 namespace UserConfig {
     // TODO: restore user overrides.

--- a/Software/src/constants/copy/en-us.h
+++ b/Software/src/constants/copy/en-us.h
@@ -52,6 +52,34 @@ static const LanguageStruct enUs = {
         "Stop'n'Go",
         "Insist"
     },
+    .AdvancedConfiguration = "Advanced Settings",
+    .AdvancedConfigurationSettingNames = {
+        "Adv. Settings ReadMe",
+        "Motor Direction",
+        "Steps Per Revolution",
+        "Pulley Teeth",
+        "Max Speed",
+        "Rail Length",
+        "Rapid Homing",
+        "Homing Sensitivity",
+        "Reset to Defaults",
+        "Apply Settings"
+    },
+    .AdvancedConfigurationSettingDescriptions = {
+        "Long press to edit. \nShort press to set value. \nChanges revert unless applied.",
+        "Homing dir toggle. \nFull depth should be penetration end away from OSSM Head.",
+        "Set to match your motor register or dip switch setting.",
+        "", // "Specify the number of teeth on your pulley.",
+        "", // "Speed limit in millimeters per second.",
+        "", // "The length of your rail in millimeters.",
+        "", // "(Future)Feature toggle to run a faster homing procedure",
+        "", // "This is a multiplier against idle current. \nHigher value will overcome more friction.",
+        "", // "Restore settings to default and restart OSSM? \n Yes: Long press \n No: Short press",
+        "Save changes and restart OSSM? \n Yes: Long press \n No: Short press"
+    },
+    // Reference board < 2.3 cannot handle this many strings being defined without the memory bootloop issue.
+    // Refactor needed to reduce memory usage.
+
 };
 
 #endif  // OSSM_SOFTWARE_EN_US_H

--- a/Software/src/ossm/OSSM.AdvancedConfiguration.cpp
+++ b/Software/src/ossm/OSSM.AdvancedConfiguration.cpp
@@ -1,0 +1,391 @@
+#include "OSSM.h"
+
+#include "extensions/u8g2Extensions.h"
+#include "utils/analog.h"
+#include "utils/format.h"
+#include <EEPROM.h>
+
+const int EEPROM_SIZE = 512; // EEPROM size in bytes
+const int EEPROM_ADDRESS = 0x0100; // Prevent conflicts with other EEPROM data
+
+SavedSettings convertToSavedSettings(const AdvancedConfigurationSettings& settings) {
+    SavedSettings savedSettings;
+
+    for (const auto& setting : settings.settings) {
+        ESP_LOGD(
+        "convertToSavedSettings",
+        "Saving setting name: %d value: %f",
+        setting.name, setting.currentValue());
+        savedSettings.savedValues.push_back({
+            .name = setting.name,
+            .value = setting.currentValue()
+        });
+    }
+
+    return savedSettings;
+}
+
+void OSSM::saveAdvancedSettings(AdvancedConfigurationSettings settings){
+    //Minimize the object down to SavedSettings. Save to EEPROM
+    SavedSettings settingsForSave = convertToSavedSettings(settings);
+
+    ESP_LOGD(
+        "saveAdvancedSettings",
+        "EEPROM Length: %d",
+        EEPROM.length());
+
+    ESP_LOGD(
+        "saveAdvancedSettings",
+        "sizeof(settingsForSave): %d",
+        sizeof(settingsForSave.savedValues));
+
+    // TODO validate that data is less than 512 bytes and then save to EEPROM
+    // if (sizeof(settingsForSave.savedValues) <= EEPROM_SIZE){
+    //     EEPROM.begin(EEPROM_SIZE);
+    //     EEPROM.put(EEPROM_ADDRESS, settingsForSave);
+    //     EEPROM.commit();
+    //     EEPROM.end();
+    // }
+}
+
+AdvancedConfigurationSettings mapSavedSettings(const AdvancedConfigurationSettings& settings) {
+    // TODO: Implement.
+
+    SavedSettings settingsFromSave;
+    // EEPROM.get(EEPROM_ADDRESS, settingsFromSave.savedValues);
+    //     ESP_LOGD(
+    //     "mapSavedSettings",
+    //     "sizeof(settingsFromSave): %d",
+    //     sizeof(settingsFromSave));
+
+    // for (auto& setting : settings.settings) {
+    //     for (const auto& savedSetting : settingsFromSave.savedValues) {
+    //         if (setting.name == savedSetting.name) {
+    //                 ESP_LOGD(
+    //                 "mapSavedSettings",
+    //                 "savedSetting.name: %d savedSetting.value: %f",
+    //                 savedSetting.name, savedSetting.value);
+    //             //setting.savedValue = savedSetting.value;
+    //             break;
+    //         }
+    //     }
+    // }
+
+    return settings;
+}
+
+AdvancedConfigurationSettings OSSM::getAdvancedSettings(){
+    AdvancedConfigurationSettings config;
+    config.settings.push_back({
+        .name = ReadMe,
+        .type = DataType::INFO,
+        .minValue = 0.0f,
+        .maxValue = 0.0f,
+        .settingPrecision = 0.0f,
+        .defaultValue = 0.0f,
+        .savedValue = std::nullopt
+    });
+
+    config.settings.push_back({
+        .name = ToggleHomeDirection,
+        .type = DataType::BOOL,
+        .minValue = static_cast<float>(false),
+        .maxValue = static_cast<float>(true),
+        .settingPrecision = 1.0f,
+        .defaultValue = static_cast<float>(false),
+        .savedValue = std::nullopt
+    });
+
+    config.settings.push_back({
+        .name = StepsPerRev,
+        .type = DataType::NUMBER,
+        .minValue = 800.0f,
+        .maxValue = 51200.0f,
+        .settingPrecision = 200.0f,
+        .defaultValue = 800.0f,
+        .savedValue = std::nullopt
+    });
+
+    config.settings.push_back({
+        .name = PulleyTeeth,
+        .type = DataType::NUMBER,
+        .minValue = 8.0f,
+        .maxValue = 32.0f,
+        .settingPrecision = 1.0f,
+        .defaultValue = 20.0f,
+        .savedValue = std::nullopt
+    });
+
+    config.settings.push_back({
+        .name = MaxSpeed,
+        .type = DataType::NUMBER,
+        .minValue = 0.0f,
+        .maxValue = 2000.0f,
+        .settingPrecision = 10.0f,
+        .defaultValue = 900.0f,
+        .savedValue = std::nullopt
+    });
+
+    config.settings.push_back({
+        .name = RailLength,
+        .type = DataType::NUMBER,
+        .minValue = 50.0f,
+        .maxValue = 1000.0f,
+        .settingPrecision = 5.0f,
+        .defaultValue = 350.0f,
+        .savedValue = std::nullopt
+    });
+
+    config.settings.push_back({
+        .name = RapidHoming,
+        .type = DataType::BOOL,
+        .minValue = static_cast<float>(false),
+        .maxValue = static_cast<float>(true),
+        .settingPrecision = 1.0f,
+        .defaultValue = static_cast<float>(false),
+        .savedValue = std::nullopt
+    });
+
+    config.settings.push_back({
+        .name = HomingCurrentLimit,
+        .type = DataType::NUMBER,
+        .minValue = 1.0f,
+        .maxValue = 20.0f,
+        .settingPrecision = .05f,
+        .defaultValue = 1.5f,
+        .savedValue = std::nullopt
+    });
+
+    config.settings.push_back({
+        .name = ResetToDefaults,
+        .type = DataType::ACTION,
+        .minValue = 0.0f,
+        .maxValue = 0.0f,
+        .settingPrecision = 0.0f,
+        .defaultValue = 0.0f,
+        .savedValue = std::nullopt
+    });
+
+    config.settings.push_back({
+        .name = Apply,
+        .type = DataType::ACTION,
+        .minValue = 0.0f,
+        .maxValue = 0.0f,
+        .settingPrecision = 0.0f,
+        .defaultValue = 0.0f,
+        .savedValue = std::nullopt
+    });
+
+    // TODO: Retrieve savedValue from EEPROM and map
+    config = mapSavedSettings(config);
+
+    return config;
+}
+
+void OSSM::drawAdvancedConfigurationEditingTask(void *pvParameters) {
+    // parse ossm from the parameters
+    OSSM *ossm = (OSSM *)pvParameters;
+    ossm->advancedConfigurationSettings = ossm->getAdvancedSettings();
+
+    // Load in the single setting we're editing
+    Setting currentAdvancedConfigurationSetting;
+    for (const auto& setting : ossm->advancedConfigurationSettings.settings) {
+        if ((int)setting.name == (int)ossm->activeAdvancedConfigurationSetting) {
+            currentAdvancedConfigurationSetting = setting;
+            break;
+        }
+    }
+    auto isInCorrectState = [](OSSM *ossm) {
+        // Add any states that you want to support here.
+        return ossm->sm->is("advancedConfiguration.settings.edit.editing"_s);
+    };
+    bool isInActionState = currentAdvancedConfigurationSetting.type == DataType::ACTION;
+    bool isInInfoState = currentAdvancedConfigurationSetting.type == DataType::INFO;
+
+    bool shouldUpdateDisplay = true;
+    bool actionPending = true;
+    String settingName =
+        UserConfig::language.AdvancedConfigurationSettingNames[(int)currentAdvancedConfigurationSetting.name];
+
+    static float valueForStorage = 0;
+    static float valueToEncoderClicks = 0;
+
+    ossm->encoder.setAcceleration(10);
+
+    // Initialize the edit view for the current setting
+    ossm->encoder.setBoundaries(currentAdvancedConfigurationSetting.minValue / currentAdvancedConfigurationSetting.settingPrecision,
+        currentAdvancedConfigurationSetting.maxValue / currentAdvancedConfigurationSetting.settingPrecision,
+        currentAdvancedConfigurationSetting.type == DataType::BOOL);
+    ossm->encoder.setEncoderValue((currentAdvancedConfigurationSetting.currentValue() / currentAdvancedConfigurationSetting.settingPrecision) - 1);
+
+    while (isInCorrectState(ossm) && actionPending) {
+
+        if(isInActionState) {
+            // Perform the action
+            switch (currentAdvancedConfigurationSetting.name) {
+                case ResetToDefaults:
+                    // Reset the setting to the default value
+                    displayMutex.lock();
+                    ossm->display.clearBuffer();
+                    //Draw the screen
+                    drawStr::title(settingName);
+                    drawStr::multiLine(0, 32, "Nothing to see here.. \nShort press to go back.");
+                    ossm->display.sendBuffer();
+                    displayMutex.unlock();
+                    break;
+                case Apply:
+                    // Save the setting to EEPROM
+                    displayMutex.lock();
+                    ossm->display.clearBuffer();
+                    //Draw the screen
+                    drawStr::title(settingName);
+                    drawStr::multiLine(0, 32, "Saving settings... \nRestarting OSSM...");
+                    ossm->display.sendBuffer();
+                    displayMutex.unlock();
+
+                    saveAdvancedSettings(ossm->advancedConfigurationSettings);
+
+                    break;
+                default:
+                    break;
+            }
+            actionPending = false;
+        }
+        else if (isInInfoState){
+            // Do nothing, tell the user they should click to return.
+            displayMutex.lock();
+            ossm->display.clearBuffer();
+            //Draw the screen
+            drawStr::title(settingName);
+            drawStr::multiLine(0, 32, "Nothing to see here.. \nShort press to go back.");
+            ossm->display.sendBuffer();
+            displayMutex.unlock();
+
+            actionPending = false;
+        }
+
+        else {
+            shouldUpdateDisplay =
+                shouldUpdateDisplay || valueToEncoderClicks != ossm->encoder.readEncoder();
+
+            valueForStorage = (ossm->encoder.readEncoder()) * currentAdvancedConfigurationSetting.settingPrecision;
+            valueToEncoderClicks = ossm->encoder.readEncoder();
+
+            if (!shouldUpdateDisplay) {
+                vTaskDelay(100);
+                continue;
+            }
+
+            // TODO: Apply value change back to the shared object, to later be saved.
+            // ossm->advancedConfigurationSettings = ...
+
+            displayMutex.lock();
+            ossm->display.clearBuffer();
+
+            String defaultValueString = "  Default value: " +
+                (currentAdvancedConfigurationSetting.type == DataType::BOOL ?
+                    (currentAdvancedConfigurationSetting.defaultValue == 0 ? "False" : "True") :
+                    String(currentAdvancedConfigurationSetting.defaultValue, currentAdvancedConfigurationSetting.settingPrecision < 1 ? 2 : 0));
+            String currentValueString = "  Value: " +
+                (currentAdvancedConfigurationSetting.type == DataType::BOOL ?
+                    (valueForStorage == 0 ? "False" : "True") :
+                    String(valueForStorage, currentAdvancedConfigurationSetting.settingPrecision < 1 ? 2 : 0));
+
+            //Draw the screen
+            drawStr::title(settingName);
+            drawStr::multiLine(0, 32, defaultValueString.c_str());
+            drawStr::multiLine(0, 44, currentValueString.c_str());
+            drawShape::settingBar("", valueToEncoderClicks, 128, 0, RIGHT_ALIGNED, 0,
+                0,
+                currentAdvancedConfigurationSetting.maxValue / currentAdvancedConfigurationSetting.settingPrecision);
+
+            ossm->display.sendBuffer();
+            displayMutex.unlock();
+        }
+
+        vTaskDelay(25); //8x faster than the normal menu, for improved feel of responsiveness when scrolling to input large values.
+    }
+
+    vTaskDelete(nullptr);
+};
+
+void OSSM::drawAdvancedConfigurationMenuTask(void *pvParameters) {
+    // parse ossm from the parameters
+    OSSM *ossm = (OSSM *)pvParameters;
+
+    ossm->advancedConfigurationSettings = ossm->getAdvancedSettings();
+
+    size_t numberOfSettings = ossm->advancedConfigurationSettings.settings.size();
+
+    auto isInCorrectState = [](OSSM *ossm) {
+        return ossm->sm->is("advancedConfiguration.settings"_s);
+    };
+
+    static float editEncoder = 0;
+    static long encoderValue = 0;
+    static float editEncoderOffset = 0;
+    static float minValue = 0;
+    static float maxValue = 100;
+    static bool editState = false;
+    int currentSelection = 0;
+    int nextSelection = 0;
+    bool shouldUpdateDisplay = true;
+    String settingName = "nextSelection";
+    String settingDescription =
+        UserConfig::language.AdvancedConfigurationSettingDescriptions[nextSelection];
+
+    ossm->encoder.setAcceleration(10);
+    ossm->encoder.setBoundaries(0, numberOfSettings * 3 - 1, true);
+    ossm->encoder.setEncoderValue(nextSelection * 3);
+
+    while (isInCorrectState(ossm)) {
+        nextSelection = ossm->encoder.readEncoder() / 3;
+        shouldUpdateDisplay =
+            shouldUpdateDisplay || currentSelection != nextSelection;
+        if (!shouldUpdateDisplay) {
+            vTaskDelay(100);
+            continue;
+        }
+        ossm->activeAdvancedConfigurationSetting = (AdvancedConfigurationSettingName)nextSelection;
+
+        settingName = UserConfig::language.AdvancedConfigurationSettingNames[nextSelection].c_str();
+
+        if (nextSelection < numberOfSettings) {
+            settingDescription =
+                UserConfig::language.AdvancedConfigurationSettingDescriptions[nextSelection];
+        } else {
+            settingDescription = "No description available";
+        }
+
+        currentSelection = nextSelection;
+
+        displayMutex.lock();
+        ossm->display.clearBuffer();
+
+        // Draw the title
+        drawStr::title(settingName);
+        drawStr::multiLine(0, 20, settingDescription);
+        drawShape::scroll(100 * nextSelection / numberOfSettings);
+
+        ossm->display.sendBuffer();
+        displayMutex.unlock();
+
+
+        vTaskDelay(200);
+    }
+
+    vTaskDelete(nullptr);
+};
+
+void OSSM::drawAdvancedConfiguration() {
+    int stackSize = 3 * configMINIMAL_STACK_SIZE;
+    xTaskCreate(drawAdvancedConfigurationMenuTask, "drawAdvancedConfigurationMenuTask", stackSize,
+                this, 1, &drawAdvancedConfigurationMenuTaskH);
+}
+
+void OSSM::drawAdvancedConfigurationEditing() {
+    int stackSize = 3 * configMINIMAL_STACK_SIZE;
+    xTaskCreate(drawAdvancedConfigurationEditingTask, "drawAdvancedConfigurationEditingTask", stackSize,
+                this, 1, &drawAdvancedConfigurationEditingTaskH);
+}
+

--- a/Software/src/ossm/OSSM.Homing.cpp
+++ b/Software/src/ossm/OSSM.Homing.cpp
@@ -38,7 +38,7 @@ void OSSM::startHomingTask(void *pvParameters) {
 
     // Stroke Engine and Simple Penetration treat this differently.
     ossm->stepper->enableOutputs();
-    ossm->stepper->setDirectionPin(Pins::Driver::motorDirectionPin, false);
+    ossm->stepper->setDirectionPin(Pins::Driver::motorDirectionPin, Config::Driver::invert);
     int16_t sign = ossm->sm->is("homing.backward"_s) ? 1 : -1;
 
     int32_t targetPositionInSteps =

--- a/Software/src/ossm/OSSM.h
+++ b/Software/src/ossm/OSSM.h
@@ -14,6 +14,7 @@
 #include "constants/Pins.h"
 #include "services/tasks.h"
 #include "structs/SettingPercents.h"
+#include "structs/AdvancedConfigurationSettings.h"
 #include "utils/RecusiveMutex.h"
 #include "utils/StateLogger.h"
 #include "utils/StrokeEngineHelper.h"
@@ -110,6 +111,8 @@ class OSSM {
                 o.stepper->disableOutputs();
             };
             auto drawHelp = [](OSSM &o) { o.drawHelp(); };
+            auto drawAdvancedConfiguration = [](OSSM &o) { o.drawAdvancedConfiguration(); };
+            auto drawAdvancedConfigurationEditing = [](OSSM &o) { o.drawAdvancedConfigurationEditing(); };
             auto drawWiFi = [](OSSM &o) { o.drawWiFi(); };
             auto drawUpdate = [](OSSM &o) { o.drawUpdate(); };
             auto drawNoUpdate = [](OSSM &o) { o.drawNoUpdate(); };
@@ -185,6 +188,7 @@ class OSSM {
                 "menu.idle"_s + buttonPress[(isOption(Menu::UpdateOSSM))] = "update"_s,
                 "menu.idle"_s + buttonPress[(isOption(Menu::WiFiSetup))] = "wifi"_s,
                 "menu.idle"_s + buttonPress[isOption(Menu::Help)] = "help"_s,
+                "menu.idle"_s + buttonPress[isOption(Menu::AdvancedConfiguration)] = "advancedConfiguration"_s,
                 "menu.idle"_s + buttonPress[(isOption(Menu::Restart))] = "restart"_s,
 
                 "simplePenetration"_s [isNotHomed] = "homing"_s,
@@ -217,6 +221,12 @@ class OSSM {
 
                 "help"_s / drawHelp = "help.idle"_s,
                 "help.idle"_s + buttonPress = "menu"_s,
+
+                "advancedConfiguration"_s / drawAdvancedConfiguration = "advancedConfiguration.settings"_s,
+                "advancedConfiguration.settings"_s  + buttonPress = "menu"_s,
+                "advancedConfiguration.settings"_s  + longPress = "advancedConfiguration.settings.edit"_s,
+                "advancedConfiguration.settings.edit"_s / drawAdvancedConfigurationEditing = "advancedConfiguration.settings.edit.editing"_s,
+                "advancedConfiguration.settings.edit.editing"_s  + buttonPress = "advancedConfiguration"_s,
 
                 "error"_s / drawError = "error.idle"_s,
                 "error.idle"_s + buttonPress / drawHelp = "error.help"_s,
@@ -263,6 +273,9 @@ class OSSM {
                                .depth = 50,
                                .pattern = StrokePatterns::SimpleStroke};
 
+    AdvancedConfigurationSettingName activeAdvancedConfigurationSetting = AdvancedConfigurationSettingName::ReadMe;
+    AdvancedConfigurationSettings advancedConfigurationSettings = AdvancedConfigurationSettings();
+
     unsigned long sessionStartTime = 0;
     int sessionStrokeCount = 0;
     double sessionDistanceMeters = 0;
@@ -290,6 +303,9 @@ class OSSM {
 
     void drawHelp();
 
+    void drawAdvancedConfiguration();
+    void drawAdvancedConfigurationEditing();
+
     void drawWiFi();
 
     void drawMenu();
@@ -314,6 +330,11 @@ class OSSM {
 
     static void drawPlayControlsTask(void *pvParameters);
     static void drawPatternControlsTask(void *pvParameters);
+
+    static AdvancedConfigurationSettings getAdvancedSettings();
+    static void saveAdvancedSettings(AdvancedConfigurationSettings settings);
+    static void drawAdvancedConfigurationMenuTask(void *pvParameters);
+    static void drawAdvancedConfigurationEditingTask(void *pvParameters);
 
     void drawUpdate();
     void drawNoUpdate();

--- a/Software/src/services/tasks.h
+++ b/Software/src/services/tasks.h
@@ -17,6 +17,8 @@ static TaskHandle_t drawPlayControlsTaskH = nullptr;
 static TaskHandle_t drawPatternControlsTaskH = nullptr;
 static TaskHandle_t wmTaskH = nullptr;
 static TaskHandle_t drawPreflightTaskH = nullptr;
+static TaskHandle_t drawAdvancedConfigurationMenuTaskH = nullptr;
+static TaskHandle_t drawAdvancedConfigurationEditingTaskH = nullptr;
 
 static TaskHandle_t runHomingTaskH = nullptr;
 static TaskHandle_t runSimplePenetrationTaskH = nullptr;

--- a/Software/src/structs/AdvancedConfigurationSettings.h
+++ b/Software/src/structs/AdvancedConfigurationSettings.h
@@ -1,0 +1,56 @@
+#ifndef SOFTWARE_ADVANCEDCONFIGURATIONSETTINGS_H
+#define SOFTWARE_ADVANCEDCONFIGURATIONSETTINGS_H
+
+#include <vector>
+#include <optional>
+
+enum class DataType {
+    NUMBER,
+    BOOL,
+    INFO,
+    ACTION
+};
+
+enum AdvancedConfigurationSettingName {
+    ReadMe,
+    //Add additional settings below this line only
+    ToggleHomeDirection,
+    StepsPerRev,
+    PulleyTeeth,
+    MaxSpeed,
+    RailLength,
+    RapidHoming,
+    HomingCurrentLimit,
+    //Add additional settings above this line only
+    ResetToDefaults,
+    Apply,
+    SettingCount
+};
+
+struct Setting {
+    AdvancedConfigurationSettingName name;
+    DataType type;
+    float minValue;
+    float maxValue;
+    float settingPrecision;
+    float defaultValue;
+    std::optional<float> savedValue;
+    float currentValue() const {
+        return savedValue.value_or(defaultValue);
+    }
+};
+
+struct AdvancedConfigurationSettings {
+    std::vector<Setting> settings;
+};
+
+struct SavedSetting {
+    AdvancedConfigurationSettingName name;
+    float value;
+};
+
+struct SavedSettings {
+    std::vector<SavedSetting> savedValues;
+};
+
+#endif  // SOFTWARE_ADVANCEDCONFIGURATIONSETTINGS_H

--- a/Software/src/structs/LanguageStruct.h
+++ b/Software/src/structs/LanguageStruct.h
@@ -23,6 +23,7 @@ struct LanguageStruct {
     String Stroke;
     String StrokeEngine;
     String StrokeTooShort;
+    String Toggle;
     String Update;
     String UpdateMessage;
     String WiFi;
@@ -32,6 +33,9 @@ struct LanguageStruct {
     String YouShouldNotBeHere;
     String StrokeEngineDescriptions[7];
     String StrokeEngineNames[7];
+    String AdvancedConfiguration;
+    String AdvancedConfigurationSettingNames[10];
+    String AdvancedConfigurationSettingDescriptions[10];
 };
 
 #endif  // OSSM_SOFTWARE_LANGUAGESTRUCT_H

--- a/Software/src/utils/StrokeEngineHelper.h
+++ b/Software/src/utils/StrokeEngineHelper.h
@@ -23,7 +23,7 @@ static motorProperties servoMotor{
     .stepsPerMillimeter =
         Config::Driver::motorStepPerRevolution /
         (Config::Driver::pulleyToothCount * Config::Driver::beltPitchMm),
-    .invertDirection = true,
+    .invertDirection = !Config::Driver::invert,
     .enableActiveLow = true,
     .stepPin = Pins::Driver::motorStepPin,
     .directionPin = Pins::Driver::motorDirectionPin,


### PR DESCRIPTION
### Description: Adds an Advance Configuration menu.

This menu will allow users to configure various settings for their machine.  
- ToggleHomeDirection
- StepsPerRev
- PulleyTeeth
- MaxSpeed
- RailLength
- RapidHoming
- HomingCurrentLimit

Settings will be saved to EEPROM and retrieved on boot to apply to Config.h

Functionality for RapidHoming to come in future PR.

Draft PR because I'm running into memory issues against < v2.3 reference boards when I attempt to include all the description strings; Needs fix.