### PR TITLE
Ptibibi/apply ramp at remote inputs

### DIFF
--- a/Software/src/constants/Config.h
+++ b/Software/src/constants/Config.h
@@ -105,6 +105,33 @@ namespace Config {
 
     }
 
+
+    /**
+        Remote Config
+*/
+    namespace Remote {
+
+        // Speed ramp of speed for SinglePenetration and StrokeEngine mode
+        // Time cycle is approximately 100-200ms in fact system load
+        constexpr float speedUpPercentPerCycle = 5.0f;
+        constexpr float speedDownPercentPerCycle = 100.0f;
+
+        // Speed ramp of stroke for StrokeEngine mode
+        // Time cycle is approximately 100-200ms in fact system load
+        constexpr float strokeUpPercentPerCycle = 5.0f;
+        constexpr float strokeDownPercentPerCycle = 10.0f;
+
+        // Speed ramp of depth for StrokeEngine mode
+        // Time cycle is approximately 100-200ms in fact system load
+        constexpr float depthUpPercentPerCycle = 5.0f;
+        constexpr float depthDownPercentPerCycle = 10.0f;
+
+        // Speed ramp of sensation for StrokeEngine mode
+        // Time cycle is approximately 100-200ms in fact system load
+        constexpr float sensationUpPercentPerCycle = 5.0f;
+        constexpr float sensationDownPercentPerCycle = 10.0f;
+    }
+
 }
 
 // Alias for "_mm" operator

--- a/Software/src/extensions/u8g2Extensions.h
+++ b/Software/src/extensions/u8g2Extensions.h
@@ -199,7 +199,7 @@ namespace drawShape {
     };
 
     // Function to draw a setting bar with label and percentage
-    static void settingBar(const String &name, float value, int x = 0,
+    static void settingBar(const String &name, float value, float target, int x = 0,
                            int y = 0, Alignment alignment = LEFT_ALIGNED,
                            int textPadding = 0, float minValue = 0,
                            float maxValue = 100) {
@@ -213,6 +213,9 @@ namespace drawShape {
         float scaledValue =
             constrain(value, minValue, maxValue) / maxValue * 100;
         int boxHeight = ceil(h * scaledValue / 100);
+        float scaledTarget =
+            constrain(target, minValue, maxValue) / maxValue * 100;
+        int targetHeight = ceil(h * scaledTarget / 100);
 
         // Position calculations based on alignment
         int barStartX = (alignment == LEFT_ALIGNED) ? x : x - w;
@@ -222,7 +225,8 @@ namespace drawShape {
                                    padding - w - textPadding;
 
         // Draw the bar and its frame
-        display.drawBox(barStartX, h - boxHeight, w, boxHeight);
+        display.drawBox(barStartX, h - boxHeight, w - 2, boxHeight);
+        display.drawVLine(barStartX + w - 2, h - targetHeight, targetHeight);
         display.drawFrame(barStartX, 0, w, h);
 
         // Set font for label and draw it
@@ -258,7 +262,7 @@ namespace drawShape {
         display.setDrawColor(1);
     }
 
-    static void settingBarSmall(float value, int x = 0, int y = 0,
+    static void settingBarSmall(float value, float target, int x = 0, int y = 0,
                                 float minValue = 0, float maxValue = 100) {
         int w = 3;
         int mid = (w - 1) / 2;
@@ -268,12 +272,16 @@ namespace drawShape {
         float scaledValue =
             constrain(value, minValue, maxValue) / maxValue * 100;
         int boxHeight = ceil(h * scaledValue / 100);
+        float scaledTarget =
+            constrain(target, minValue, maxValue) / maxValue * 100;
+        int targetHeight = ceil(h * scaledTarget / 100);
         // draw a single pixel line
         int lineH = boxHeight > 0 ? constrain(64 - boxHeight - 2, 0, 64) : 64;
         display.drawVLine(x + mid, y, lineH);
+        display.drawVLine(x + w - 1, h - targetHeight, targetHeight);
 
         // draw a box 3px wide
-        display.drawBox(x, 64 - boxHeight, w, boxHeight);
+        display.drawBox(x, 64 - boxHeight, w - 1, boxHeight);
     }
 
     // Function to draw lines between a variadic number of points

--- a/Software/src/ossm/OSSM.PlayControls.cpp
+++ b/Software/src/ossm/OSSM.PlayControls.cpp
@@ -25,7 +25,18 @@ void OSSM::drawPlayControlsTask(void *pvParameters) {
 
     auto menuString = menuStrings[ossm->menuOption];
 
-    SettingPercents next = {0, 0, 0, 0};
+    SettingPercents next;
+    next.speed = ossm->setting.speed;
+    next.stroke = ossm->setting.stroke;
+    next.depth = ossm->setting.depth;
+    next.sensation = ossm->setting.sensation;
+
+    SettingPercents target;
+    target.speed = ossm->setting.speed;
+    target.stroke = ossm->setting.stroke;
+    target.depth = ossm->setting.depth;
+    target.sensation = ossm->setting.sensation;
+
     unsigned long displayLastUpdated = 0;
 
     /**
@@ -53,52 +64,81 @@ void OSSM::drawPlayControlsTask(void *pvParameters) {
     bool isStrokeEngine =
         ossm->sm->is("strokeEngine"_s) || ossm->sm->is("strokeEngine.idle"_s);
 
-    bool shouldUpdateDisplay = false;
-
     // This small break gives the encoder a minute to settle.
     vTaskDelay(100);
-
     while (isInCorrectState(ossm)) {
         // Always assume the display should not update.
-        shouldUpdateDisplay = false;
+        bool shouldUpdateDisplay = false;
 
-        next.speedKnob =
-            getAnalogAveragePercent(SampleOnPin{Pins::Remote::speedPotPin, 50});
-        ossm->setting.speedKnob = next.speedKnob;
+        /**
+         * ////////////////////////////////////////////
+         * ///////////    Manage analog    ////////////
+         * ////////////////////////////////////////////
+         */
+        target.speed = round(getAnalogAveragePercent(SampleOnPin{Pins::Remote::speedPotPin, 50}));
+
+        /**
+         * /////////////////////////////////////////////
+         * ///////////    Manage encoder    ////////////
+         * /////////////////////////////////////////////
+         */
         encoder = ossm->encoder.readEncoder();
-
-        next.speed = next.speedKnob;
-
-        if (next.speed != ossm->setting.speed) {
-            shouldUpdateDisplay = true;
-            ossm->setting.speed = next.speed;
-        }
-
         switch (ossm->playControl) {
+            // STROKE used for SinglePenetration and StrokeEngine
             case PlayControls::STROKE:
-                next.stroke = encoder;
-                shouldUpdateDisplay = shouldUpdateDisplay ||
-                                      next.stroke - ossm->setting.stroke >= 1;
-                ossm->setting.stroke = next.stroke;
+                target.stroke = encoder;
                 break;
+            // SENSATION used for StrokeEngine
             case PlayControls::SENSATION:
-                next.sensation = encoder;
-                shouldUpdateDisplay =
-                    shouldUpdateDisplay ||
-                    next.sensation - ossm->setting.sensation >= 1;
-                ossm->setting.sensation = next.sensation;
+                target.sensation = encoder;
                 break;
+            // DEPTH used for StrokeEngine
             case PlayControls::DEPTH:
-                next.depth = encoder;
-                shouldUpdateDisplay = shouldUpdateDisplay ||
-                                      next.depth - ossm->setting.depth >= 1;
-                ossm->setting.depth = next.depth;
+                target.depth = encoder;
                 break;
         }
 
-        shouldUpdateDisplay =
-            shouldUpdateDisplay || millis() - displayLastUpdated > 1000;
+        /**
+         * /////////////////////////////////////////////
+         * ///////////   Apply input ramp   ////////////
+         * /////////////////////////////////////////////
+         */
+        next.speed = applyRamp(next.speed, target.speed,
+                               Config::Remote::speedUpPercentPerCycle,
+                               Config::Remote::speedDownPercentPerCycle);
+        next.stroke = applyRamp(next.stroke, target.stroke,
+                                Config::Remote::strokeUpPercentPerCycle,
+                                Config::Remote::strokeDownPercentPerCycle);
+        next.sensation = applyRamp(next.sensation, target.sensation,
+                                   Config::Remote::sensationUpPercentPerCycle,
+                                   Config::Remote::sensationDownPercentPerCycle);
+        next.depth = applyRamp(next.depth, target.depth,
+                               Config::Remote::depthUpPercentPerCycle,
+                               Config::Remote::depthDownPercentPerCycle);
 
+        /**
+         * //////////////////////////////////////////////
+         * /////////// Inputs update display ////////////
+         * //////////////////////////////////////////////
+         */
+        shouldUpdateDisplay = shouldUpdateDisplay || next.speed - ossm->setting.speed != 0;
+        shouldUpdateDisplay = shouldUpdateDisplay || next.stroke - ossm->setting.stroke != 0;
+        shouldUpdateDisplay = shouldUpdateDisplay || next.sensation - ossm->setting.sensation != 0;
+        shouldUpdateDisplay = shouldUpdateDisplay || next.depth - ossm->setting.depth != 0;
+
+        shouldUpdateDisplay = shouldUpdateDisplay || millis() - displayLastUpdated > 1000;
+
+        /**
+         * ///////////////////////////////////////////////
+         * /////////// Apply next input value ////////////
+         * ///////////////////////////////////////////////
+         */
+        ossm->setting.speed = next.speed;
+        ossm->setting.stroke = next.stroke;
+        ossm->setting.sensation = next.sensation;
+        ossm->setting.depth = next.depth;
+
+        // Waiting and continue if display not updated
         if (!shouldUpdateDisplay) {
             vTaskDelay(100);
             continue;
@@ -113,33 +153,33 @@ void OSSM::drawPlayControlsTask(void *pvParameters) {
         ossm->display.clearBuffer();
         ossm->display.setFont(Config::Font::base);
 
-        drawShape::settingBar(UserConfig::language.Speed, next.speedKnob);
+        drawShape::settingBar(UserConfig::language.Speed, target.speed, next.speed);
 
         if (isStrokeEngine) {
             switch (ossm->playControl) {
                 case PlayControls::STROKE:
-                    drawShape::settingBarSmall(ossm->setting.sensation, 125);
-                    drawShape::settingBarSmall(ossm->setting.depth, 120);
-                    drawShape::settingBar(strokeString, ossm->setting.stroke,
+                    drawShape::settingBarSmall(target.sensation, next.sensation, 125);
+                    drawShape::settingBarSmall(target.depth, next.depth, 120);
+                    drawShape::settingBar(strokeString, target.stroke, next.stroke,
                                           118, 0, RIGHT_ALIGNED);
                     break;
                 case PlayControls::SENSATION:
-                    drawShape::settingBar("Sensation", ossm->setting.sensation,
+                    drawShape::settingBar("Sensation", target.sensation, next.sensation,
                                           128, 0, RIGHT_ALIGNED, 10);
-                    drawShape::settingBarSmall(ossm->setting.depth, 113);
-                    drawShape::settingBarSmall(ossm->setting.stroke, 108);
+                    drawShape::settingBarSmall(target.depth, next.depth, 113);
+                    drawShape::settingBarSmall(target.stroke, next.stroke, 108);
 
                     break;
                 case PlayControls::DEPTH:
-                    drawShape::settingBarSmall(ossm->setting.sensation, 125);
-                    drawShape::settingBar("Depth", ossm->setting.depth, 123, 0,
-                                          RIGHT_ALIGNED, 5);
-                    drawShape::settingBarSmall(ossm->setting.stroke, 108);
+                    drawShape::settingBarSmall(target.sensation, next.sensation, 125);
+                    drawShape::settingBar("Depth", target.depth, next.depth,
+                                          123, 0, RIGHT_ALIGNED, 5);
+                    drawShape::settingBarSmall(target.stroke, next.stroke, 108);
 
                     break;
             }
         } else {
-            drawShape::settingBar(strokeString, ossm->encoder.readEncoder(),
+            drawShape::settingBar(strokeString, target.stroke, next.stroke,
                                   118, 0, RIGHT_ALIGNED);
         }
 
@@ -187,4 +227,14 @@ void OSSM::drawPlayControls() {
     int stackSize = 3 * configMINIMAL_STACK_SIZE;
     xTaskCreate(drawPlayControlsTask, "drawPlayControlsTask", stackSize, this,
                 1, &drawPlayControlsTaskH);
+}
+
+// Apply ramp in current value to move to target value
+float OSSM::applyRamp(float current, float target,
+                      float increaseValue, float decreaseValue) {
+    if (target > current)
+        current = constrain(current + increaseValue, current, target);
+    else
+        current = constrain(current - decreaseValue, target, current);
+    return current;
 }

--- a/Software/src/ossm/OSSM.SimplePenetration.cpp
+++ b/Software/src/ossm/OSSM.SimplePenetration.cpp
@@ -25,7 +25,7 @@ void OSSM::startSimplePenetrationTask(void *pvParameters) {
                             ossm->setting.speed * ossm->setting.speed /
                             Config::Advanced::accelerationScaling;
 
-        bool isSpeedZero = ossm->setting.speedKnob <
+        bool isSpeedZero = ossm->setting.speed <
                            Config::Advanced::commandDeadZonePercentage;
         bool isSpeedChanged =
             !isSpeedZero && abs(speed - lastSpeed) >

--- a/Software/src/ossm/OSSM.h
+++ b/Software/src/ossm/OSSM.h
@@ -313,6 +313,7 @@ class OSSM {
     static void drawMenuTask(void *pvParameters);
 
     static void drawPlayControlsTask(void *pvParameters);
+    static float applyRamp(float current, float target, float increaseValue, float decreaseValue);
     static void drawPatternControlsTask(void *pvParameters);
 
     void drawUpdate();

--- a/Software/src/structs/SettingPercents.h
+++ b/Software/src/structs/SettingPercents.h
@@ -17,7 +17,6 @@ struct SettingPercents {
     float sensation;
     float depth;
     StrokePatterns pattern;
-    float speedKnob;
 };
 
 #endif  // SOFTWARE_SETTINGPERCENTS_H


### PR DESCRIPTION
# Remote: apply ramp on remote inputs

Reduce injurie risk by appling ramp to limit brutal variation of inputs

### Software/src/constants/Config.h
* Define ramp settings in config

### Software/src/ossm/OSSM.PlayControls.cpp
* Code grouping by usage
* Unify & init inputs variables
* Apply ramp on inputs
* Show inputs ramp on display

### Software/src/ossm/OSSM.h
* create applyRamp() static function to drive ramp

### Software/src/extensions/u8g2Extensions.h
* Update settingBar & settingBarSmall to show ramp

 ### Software/src/structs/SettingPercents.h
* Removing unused speedKnob variable from SettingPercents

### Software/src/ossm/OSSM.SimplePenetration.cpp
* replaced speedKnob by speed