### PR TITLE
homing: move applied offset in config file

### DIFF
--- a/Software/src/constants/Config.h
+++ b/Software/src/constants/Config.h
@@ -66,6 +66,9 @@ namespace Config {
         // If the stroke length is less than this value, then the stroke is
         // likely the result of a poor homing.
         constexpr float minStrokeLengthMm = 50.0_mm;
+
+        // Applied offset after homing process.
+        constexpr float homingOffsetMn = 10_mm;
     }
 
     /**

--- a/Software/src/ossm/OSSM.Homing.cpp
+++ b/Software/src/ossm/OSSM.Homing.cpp
@@ -90,7 +90,7 @@ void OSSM::startHomingTask(void *pvParameters) {
 
         // step away from the hard stop, with your hands in the air!
         int32_t currentPosition = ossm->stepper->getCurrentPosition();
-        ossm->stepper->moveTo(currentPosition - sign * 10_mm, true);
+        ossm->stepper->moveTo(currentPosition - sign * Config::Driver::homingOffsetMn, true);
 
         // measure and save the current position
         ossm->measuredStrokeSteps =


### PR DESCRIPTION
## homing: move applied offset in config file

### Software/src/constants/Config.h
Add homing offset

### Software/src/ossm/OSSM.Homing.cpp
Replace homing offset constant by homingOffsetMn from config file