### PR TITLE
[NOT FOR MERGE] - Increase current sensor homing threshold from 1.5 to 5.0 

### DIFF
--- a/Software/src/constants/Config.h
+++ b/Software/src/constants/Config.h
@@ -35,7 +35,7 @@ namespace Config {
 
         // This is the measured current that use to infer when the device has
         // reached the end of its stroke. during "Homing".
-        constexpr float sensorlessCurrentLimit = 1.5f;
+        constexpr float sensorlessCurrentLimit = 5.0f;  //Increased to 5.0 from 1.5
 
         constexpr float stepsPerMM =
             motorStepPerRevolution / (pulleyToothCount * beltPitchMm);

--- a/Software/src/ossm/OSSM.Homing.cpp
+++ b/Software/src/ossm/OSSM.Homing.cpp
@@ -75,7 +75,7 @@ void OSSM::startHomingTask(void *pvParameters) {
                             SampleOnPin{Pins::Driver::currentSensorPin, 200}) -
                         ossm->currentSensorOffset;
 
-        ESP_LOGV("Homing", "Current: %f", current);
+        ESP_LOGD("Homing", "Current: %f", current);
 
         bool isCurrentOverLimit =
             current > Config::Driver::sensorlessCurrentLimit;


### PR DESCRIPTION
To assist a user troubleshooting, as well as to exercise a new github PR action workflow.