### PR TITLE
[NOT FOR MERGE] - Increase sensorlessCurrentLimit from 1.5 to 5.0

### DIFF
--- a/Software/src/constants/Config.h
+++ b/Software/src/constants/Config.h
@@ -35,7 +35,7 @@ namespace Config {
 
         // This is the measured current that use to infer when the device has
         // reached the end of its stroke. during "Homing".
-        constexpr float sensorlessCurrentLimit = 1.5f;
+        constexpr float sensorlessCurrentLimit = 5.0f;
 
         constexpr float stepsPerMM =
             motorStepPerRevolution / (pulleyToothCount * beltPitchMm);


### PR DESCRIPTION
To assist a user troubleshooting, as well as to exercise a new github PR action workflow.