### PR TITLE
Test branch for speed pot dead zone logic refactor, with deadzone set to 25%

### DIFF
--- a/Software/src/constants/Config.h
+++ b/Software/src/constants/Config.h
@@ -98,12 +98,15 @@ namespace Config {
         // effective zero to the home switch This is to stop the home switch
         // being smacked constantly
         constexpr float strokeZeroOffsetMm = 6.0f;
+
         // The minimum value of the pot in percent
         // prevents noisy pots registering commands when turned down to zero by
         // user
-        constexpr float commandDeadZonePercentage = 1.0f;
-        // affects acceleration in stepper trajectory (Aggressiveness of motion)
+        // 03.28.2025 This deadzone now applies inside getAnalogAveragePercent()
+        // allowing it to apply to SimplePenetration and StrokeEngine
+        constexpr float commandDeadZonePercentage = 25.0f;
 
+        // affects acceleration in stepper trajectory (Aggressiveness of motion)
         constexpr float accelerationScaling = 100.0f;
 
     }

--- a/Software/src/ossm/OSSM.Preflight.cpp
+++ b/Software/src/ossm/OSSM.Preflight.cpp
@@ -34,7 +34,7 @@ void OSSM::drawPreflightTask(void *pvParameters) {
     do {
         speedPercentage =
             getAnalogAveragePercent(SampleOnPin{Pins::Remote::speedPotPin, 50});
-        if (speedPercentage < Config::Advanced::commandDeadZonePercentage) {
+        if (speedPercentage == 0.0f) {
             ossm->sm->process_event(Done{});
             break;
         };

--- a/Software/src/ossm/OSSM.SimplePenetration.cpp
+++ b/Software/src/ossm/OSSM.SimplePenetration.cpp
@@ -25,11 +25,9 @@ void OSSM::startSimplePenetrationTask(void *pvParameters) {
                             ossm->setting.speed * ossm->setting.speed /
                             Config::Advanced::accelerationScaling;
 
-        bool isSpeedZero = ossm->setting.speedKnob <
-                           Config::Advanced::commandDeadZonePercentage;
+        bool isSpeedZero = ossm->setting.speedKnob == 0;
         bool isSpeedChanged =
-            !isSpeedZero && abs(speed - lastSpeed) >
-                                5 * Config::Advanced::commandDeadZonePercentage;
+            !isSpeedZero && abs(speed - lastSpeed) > 1.0f; //Keep some dead-zone for analog fluctuation
         bool isAtTarget =
             abs(targetPosition - ossm->stepper->getCurrentPosition()) == 0;
 
@@ -75,9 +73,8 @@ void OSSM::startSimplePenetrationTask(void *pvParameters) {
 
         ossm->stepper->moveTo(targetPosition, false);
 
-        if (ossm->setting.speed > Config::Advanced::commandDeadZonePercentage &&
-            ossm->setting.stroke >
-                (long)Config::Advanced::commandDeadZonePercentage) {
+        if (ossm->setting.speed > 0 &&
+            ossm->setting.stroke > (long)1.0f) {
             fullStrokeCount++;
             ossm->sessionStrokeCount = floor(fullStrokeCount / 2);
 


### PR DESCRIPTION
Deadzone is now applied inside the getAnalogAveragePercent()
This allows it to apply to both simplepenetration and strokeengine modes
Also addresses UI discrepancy in simplepenetration where speed bar would visually increase even while value was within the deadzone