### PR TITLE
Remove trailing slash from link to Toy Mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Attempting to use a stepper or other motor is not recommended; while it may be t
  - [Remote](Printed%20Parts/Remote/)
    - Body
    - Knobs
- - [Toy Mounting](Printed%20Parts/Toy%20Mounting/)
+ - [Toy Mounting](Printed%20Parts/Toy%20Mounting)
    - Flange Base Plate with Clamping Ring (Tie-Down or Suction)
    - Double Double (Vac-U-Lock)
  - [Mounting](Printed%20Parts/Mounting/)


### PR DESCRIPTION
By default the trailing slash appends a README.md to the link however this directory has one that's empty. We should trust github or gitdoc to generate a file index.

Testing this behaviour on this link specifically as we're not sure of the outcome.