### PR TITLE
feat(funscript-player): add built-in example funscript loader (RAD-1897)

### DIFF
--- a/Documentation/ossm/tools/funscript-player.mdx
+++ b/Documentation/ossm/tools/funscript-player.mdx
@@ -29,12 +29,14 @@ Web Bluetooth is **not supported** on iOS devices (iPhone/iPad) or in Safari/Fir
 <Steps>
   <Step title="Load your media files">
     Click the file pickers to select your video file and matching `.funscript` or `.csv` file. The funscript filename should match the video filename (e.g., `my-video.mp4` and `my-video.funscript`).
+
+    Don't have a funscript yet? Click **Or load built-in example funscript** under the funscript picker to load a short demo script that ramps from slow to faster strokes so you can verify everything is working before sourcing your own scripts.
   </Step>
-  
+
   <Step title="Connect to your OSSM">
     Click **Connect to OSSM** and select your device from the Bluetooth list. The OSSM will automatically enter streaming mode.
   </Step>
-  
+
   <Step title="Play the video">
     Press play on the video player. Position commands are sent in real-time as the video plays, keeping your OSSM synchronized with the content.
   </Step>

--- a/Documentation/snippets/ossm/funscript-player.jsx
+++ b/Documentation/snippets/ossm/funscript-player.jsx
@@ -447,6 +447,56 @@ export const OssmFunscriptPlayer = () => {
     }
   };
 
+  // Load a built-in example funscript so new users can test the player
+  // without needing to find a script first. Loops a simple ~30s pattern that
+  // ramps from slow to faster strokes so behaviour at varying speeds is visible.
+  const handleLoadExampleFunscript = () => {
+    const exampleFunscript = {
+      version: '1.0',
+      range: 100,
+      inverted: false,
+      actions: (() => {
+        const actions = [];
+        let t = 0;
+        // Phase 1: slow long strokes (~3s per stroke) for 6 strokes
+        for (let i = 0; i < 6; i += 1) {
+          actions.push({ at: t, pos: 0 });
+          t += 1500;
+          actions.push({ at: t, pos: 100 });
+          t += 1500;
+        }
+        // Phase 2: medium strokes (~1.5s per stroke) for 8 strokes
+        for (let i = 0; i < 8; i += 1) {
+          actions.push({ at: t, pos: 0 });
+          t += 750;
+          actions.push({ at: t, pos: 100 });
+          t += 750;
+        }
+        // Phase 3: faster shorter strokes (~0.6s per stroke) for 10 strokes
+        for (let i = 0; i < 10; i += 1) {
+          actions.push({ at: t, pos: 30 });
+          t += 300;
+          actions.push({ at: t, pos: 100 });
+          t += 300;
+        }
+        // End: return to fully extended (pos 0)
+        actions.push({ at: t, pos: 0 });
+        return actions;
+      })(),
+    };
+
+    const fileName = 'example.funscript';
+    const blob = new Blob([JSON.stringify(exampleFunscript)], {
+      type: 'application/json',
+    });
+    const fakeFile = new File([blob], fileName, { type: 'application/json' });
+    setFunscriptFile(fakeFile);
+    if (parseFunscript(JSON.stringify(exampleFunscript))) {
+      resetPlayback();
+      addLog('INFO', 'Loaded built-in example funscript');
+    }
+  };
+
   // Video event handlers
   const handleVideoPlay = () => {
     addLog('INFO', 'Video playing');
@@ -603,6 +653,13 @@ export const OssmFunscriptPlayer = () => {
                 {funscriptFile ? funscriptFile.name : 'Click to select .funscript'}
               </div>
             </label>
+            <button
+              type="button"
+              onClick={handleLoadExampleFunscript}
+              className="mt-2 w-full text-xs font-medium text-violet-600 dark:text-violet-400 hover:underline"
+            >
+              Or load built-in example funscript
+            </button>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Adds an **Or load built-in example funscript** button to the OSSM Funscript Player documentation page. This allows newcomers to try the player end-to-end before sourcing their own `.funscript` files.

The example is generated in-memory and ramps from slow long strokes to faster shorter ones, so users can also see how the OSSM responds across speeds.

## Why

From [Linear RAD-1897](https://linear.app/researchanddesire/issue/RAD-1897/ossm-feature-request-from-thomas) (Discord user Thomas):

> On the documentation page for the funscript player, have an option to load a simple example script so I can test how things work without digging up a script somewhere.

## Changes

- `Documentation/snippets/ossm/funscript-player.jsx`: add `handleLoadExampleFunscript` and a small text button under the file picker.
- `Documentation/ossm/tools/funscript-player.mdx`: mention the new button in the **Load your media files** step.

## Related

- Linear: https://linear.app/researchanddesire/issue/RAD-1897