### PR TITLE
fix(funscript-player): address RAD-2053 safety + UX issues

### DIFF
--- a/Documentation/snippets/ossm/funscript-player.jsx
+++ b/Documentation/snippets/ossm/funscript-player.jsx
@@ -23,6 +23,11 @@ export const OssmFunscriptPlayer = () => {
   const [funscriptFile, setFunscriptFile] = useState(null);
   const [funscriptActions, setFunscriptActions] = useState([]);
   const [funscriptSimpleActions, setFunscriptSimpleActions] = useState([]);
+  // Max position observed in the entire script (0-100). Used to render a
+  // safety marker on the position bar so users can gauge the deepest stroke
+  // the script will ever ask for, regardless of current playback time.
+  // See RAD-2053 (Issue 4).
+  const [funscriptMaxPosition, setFunscriptMaxPosition] = useState(0);
   const [isSimple, setIsSimple] = useState(true);
   const [isReverse, setIsReverse] = useState(false);
 
@@ -228,8 +233,14 @@ export const OssmFunscriptPlayer = () => {
       commandCharacteristicRef.current = await service.getCharacteristic(OSSM_COMMAND_CHARACTERISTIC_UUID);
       addLog('INFO', 'Got command characteristic');
 
-      // Enter streaming mode
+      // Enter streaming mode. We also send `set:speed:0` first to clear any
+      // residual safety-shutdown state before re-arming the streaming mode.
+      // Some firmware versions latch a safety state across BLE
+      // reconnects until a fresh streaming command is issued. See
+      // RAD-2053 (Issue 3) — full recovery still requires firmware fixes,
+      // but this gives the dashboard a best-effort reset hook.
       addLog('INFO', 'Entering streaming mode...');
+      await sendCommand('set:speed:0');
       await sendCommand('go:streaming');
 
       speedKnobCharacteristicRef.current = await service.getCharacteristic(OSSM_SPEED_KNOB_CHARACTERISTIC_UUID);
@@ -322,6 +333,7 @@ export const OssmFunscriptPlayer = () => {
     }
     if (!data.actions || !Array.isArray(data.actions)) {
       setError(`Failed to parse funscript`);
+      setFunscriptMaxPosition(0);
       return false;
     }
     var lastDirection = 0;
@@ -340,10 +352,24 @@ export const OssmFunscriptPlayer = () => {
     )
     data.simpleActions;
 
+    // Compute max position across the entire script (0-100). This drives a
+    // static safety marker on the position bar so users see the deepest
+    // stroke the script will ever request before playback reaches that
+    // point. See RAD-2053 (Issue 4).
+    let maxPos = 0;
+    for (const action of data.actions) {
+      const pos = Number(action?.pos);
+      if (Number.isFinite(pos) && pos > maxPos) {
+        maxPos = pos;
+      }
+    }
+    const clampedMaxPos = Math.max(0, Math.min(100, Math.round(maxPos)));
+
     setFunscriptActions(data.actions);
     setFunscriptSimpleActions(data.simpleActions);
+    setFunscriptMaxPosition(clampedMaxPos);
 
-    addLog('INFO', `Loaded ${data.actions.length} actions`);
+    addLog('INFO', `Loaded ${data.actions.length} actions (max pos ${clampedMaxPos})`);
 
     if (data.version) addLog('INFO', `Funscript version: ${data.version}`);
     if (data.inverted) addLog('INFO', 'Script is inverted');
@@ -403,7 +429,15 @@ export const OssmFunscriptPlayer = () => {
     setIsPlaying(true);
     syncIntervalRef.current = setInterval(syncFunscript, 2);
     addLog('INFO', 'Started sync');
-  }, [syncFunscript, addLog]);
+    // Warn when starting playback with Max Speed at 0. Raising the speed
+    // mid-playback puts the OSSM into a hard safety shutdown that only a
+    // power cycle clears. Surfacing this early prevents the user from
+    // having to recover from a stuck state. See RAD-2053 (Issue 2).
+    if (speed === 0) {
+      addLog('ERR', 'Max Speed is 0 — raise it BEFORE pressing play, or playback may trigger a safety shutdown');
+      setError('Max Speed is set to 0. Set it to a non-zero value before starting playback to avoid a safety shutdown that requires a power-cycle to clear.');
+    }
+  }, [syncFunscript, addLog, speed]);
 
   // Stop sync loop
   const stopSync = useCallback(() => {
@@ -570,9 +604,16 @@ export const OssmFunscriptPlayer = () => {
               Video File
             </label>
             <label className="block cursor-pointer">
+              {/*
+                Intentionally omit `accept` here. On Android, providing
+                `accept="video/*"` (or any explicit MIME) causes the system
+                picker to surface only the Photos/Gallery app, which hides
+                files on network drives and SD-cards. Leaving `accept` off
+                lets users open the full file browser via the standard
+                share-sheet. See RAD-2053 (Issue 1).
+              */}
               <input
                 type="file"
-                accept="video/*"
                 onChange={handleVideoSelect}
                 className="hidden"
               />
@@ -629,13 +670,36 @@ export const OssmFunscriptPlayer = () => {
           )}
         </div>
 
-        {/* Position bar */}
-        <div className="h-2 bg-zinc-200 dark:bg-zinc-700 rounded-full overflow-hidden mb-4">
+        {/*
+          Position bar with a static "script max depth" marker.
+          The filled violet bar shows the live commanded position.
+          The amber tick is the deepest position the script will EVER
+          request, computed from the full action list at load time. This
+          lets the user gauge the script's true peak depth before the
+          peak section plays. See RAD-2053 (Issue 4).
+        */}
+        <div className="relative h-2 bg-zinc-200 dark:bg-zinc-700 rounded-full overflow-hidden mb-1">
           <div
             className="h-full bg-violet-500 transition-all duration-75"
             style={{ width: `${currentPosition}%` }}
           />
+          {funscriptMaxPosition > 0 && (
+            <div
+              aria-label={`Script max depth: ${funscriptMaxPosition}`}
+              title={`Script max depth: ${funscriptMaxPosition}`}
+              className="absolute top-0 h-full w-0.5 bg-amber-500"
+              style={{ left: `${funscriptMaxPosition}%` }}
+            />
+          )}
         </div>
+        {funscriptMaxPosition > 0 && (
+          <div className="flex justify-between text-xs text-zinc-500 dark:text-zinc-400 mb-3">
+            <span>Live position: {currentPosition}</span>
+            <span className="text-amber-600 dark:text-amber-400">
+              Script max depth: {funscriptMaxPosition}
+            </span>
+          </div>
+        )}
 
         {/* Stats */}
         <div className="grid grid-cols-2 sm:grid-cols-6 gap-3">

--- a/Documentation/snippets/ossm/funscriptMaxPosition.mjs
+++ b/Documentation/snippets/ossm/funscriptMaxPosition.mjs
@@ -1,0 +1,31 @@
+/**
+ * Pure helper exported so the logic that drives the funscript player's
+ * "Script max depth" safety marker can be unit-tested independently of
+ * the Mintlify snippet (which is loaded at runtime as JSX and not
+ * importable by a test runner).
+ *
+ * Mirrors the inline computation in `funscript-player.jsx`.
+ *
+ * See RAD-2053 (Issue 4): the existing position bar showed only the
+ * highest depth observed up to the current playback time, which a user
+ * could mistake for the script's true peak. The "static max" computed
+ * here is rendered as a separate amber tick on the position bar so the
+ * user can see the deepest stroke the script will ever request before
+ * playback reaches that section.
+ *
+ * @param {Array<{pos?: unknown}>} actions
+ * @returns {number} clamped 0-100 integer
+ */
+export const computeFunscriptMaxPosition = (actions) => {
+  if (!Array.isArray(actions) || actions.length === 0) {
+    return 0;
+  }
+  let maxPos = 0;
+  for (const action of actions) {
+    const pos = Number(action?.pos);
+    if (Number.isFinite(pos) && pos > maxPos) {
+      maxPos = pos;
+    }
+  }
+  return Math.max(0, Math.min(100, Math.round(maxPos)));
+};

--- a/Documentation/snippets/ossm/funscriptMaxPosition.test.mjs
+++ b/Documentation/snippets/ossm/funscriptMaxPosition.test.mjs
@@ -1,0 +1,52 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { computeFunscriptMaxPosition } from './funscriptMaxPosition.mjs';
+
+describe('computeFunscriptMaxPosition (RAD-2053 Issue 4)', () => {
+  it('returns 0 for empty / non-array input', () => {
+    assert.equal(computeFunscriptMaxPosition([]), 0);
+    assert.equal(computeFunscriptMaxPosition(null), 0);
+    assert.equal(computeFunscriptMaxPosition(undefined), 0);
+    assert.equal(computeFunscriptMaxPosition({}), 0);
+  });
+
+  it('returns the highest pos across all actions, not the last seen', () => {
+    const actions = [
+      { at: 0, pos: 10 },
+      { at: 100, pos: 20 },
+      { at: 200, pos: 95 }, // peak before mid playback
+      { at: 300, pos: 30 },
+      { at: 400, pos: 50 },
+    ];
+    assert.equal(computeFunscriptMaxPosition(actions), 95);
+  });
+
+  it('clamps values above 100 to 100', () => {
+    const actions = [{ at: 0, pos: 250 }];
+    assert.equal(computeFunscriptMaxPosition(actions), 100);
+  });
+
+  it('treats negative positions as 0 (clamps low end)', () => {
+    const actions = [{ at: 0, pos: -10 }, { at: 100, pos: -5 }];
+    assert.equal(computeFunscriptMaxPosition(actions), 0);
+  });
+
+  it('ignores non-numeric pos entries', () => {
+    const actions = [
+      { at: 0, pos: 'oops' },
+      { at: 100, pos: NaN },
+      { at: 200, pos: 42 },
+      { at: 300 },
+    ];
+    assert.equal(computeFunscriptMaxPosition(actions), 42);
+  });
+
+  it('rounds fractional positions to nearest integer', () => {
+    const actions = [
+      { at: 0, pos: 49.4 },
+      { at: 100, pos: 49.6 },
+    ];
+    assert.equal(computeFunscriptMaxPosition(actions), 50);
+  });
+});


### PR DESCRIPTION
Improvements to the OSSM funscript player snippet at `Documentation/snippets/ossm/funscript-player.jsx`, addressing user-reported issues from Linear ticket [RAD-2053](https://linear.app/researchanddesire/issue/RAD-2053/re-ossm-funscripts) (Gorgias [#261961033](https://researchanddesire.gorgias.com/app/ticket/261961033)).

## Issues fixed

1. **Android video picker (Issue 1)** — dropped `accept="video/*"` so the system picker opens the full file browser instead of forcing the user into the Photos / Gallery app, which hides files on network drives and SD-card storage providers.

2. **Max-speed=0 warning (Issue 2)** — warn loudly when the user starts playback with Max Speed at 0. Raising it mid-playback puts the OSSM into a safety shutdown that requires a power-cycle to clear, so we now surface the issue *before* they get stuck. The warning shows in both the inline error banner and the debug log.

3. **Streaming-mode reset on connect (Issue 3, partial)** — also send `set:speed:0` immediately before `go:streaming` when reconnecting, giving the dashboard a best-effort recovery hook for sticky safety state. Full recovery for the persistent safety-shutdown latch still requires firmware-side work — flagged for the firmware team.

4. **Static script max-depth marker (Issue 4)** — compute the highest `pos` value across the entire funscript at parse time and render it as an amber tick on the position bar plus a numeric readout, so users can gauge the deepest stroke the script will EVER request before playback reaches that section. The previous bar only reflected the max observed up to the current playback position, which was a safety risk.

## Tests

Added `Documentation/snippets/ossm/funscriptMaxPosition.{mjs,test.mjs}` — a pure helper exporting the max-position algorithm with a 6-case Node `node:test` suite covering empty input, peak detection, clamping, NaN/missing pos, and rounding. Run with:

```
node --test Documentation/snippets/ossm/funscriptMaxPosition.test.mjs
```

## Related

- rad-app submodule-pointer bump PR: https://github.com/researchanddesire/rad-app/pulls?q=is%3Apr+head%3Acursor%2Ftriage-issue-resolution-b347 (linked when opened)
- Linear: [RAD-2053](https://linear.app/researchanddesire/issue/RAD-2053/re-ossm-funscripts)