### PR TITLE
avoid zero division on repeated stream position

### DIFF
--- a/Software/src/ossm/streaming/streaming.cpp
+++ b/Software/src/ossm/streaming/streaming.cpp
@@ -27,7 +27,12 @@ static void startStreamingTask(void *pvParameters) {
     };
 
     auto best = std::chrono::steady_clock::now();
-    PositionTime lastPositionTime;
+    PositionTime lastPositionTime{
+        0,
+        0,
+        std::chrono::steady_clock::now(),
+        0
+    };
     
     // Reset the queue to clear any existing commands
     targetQueue = {};
@@ -54,7 +59,11 @@ static void startStreamingTask(void *pvParameters) {
         PositionTime targetPositionTime = targetQueue.front();
         //Wait for previous command to finish if it isn't moving in the same direction.
         int16_t distance = targetPositionTime.position - lastPositionTime.position;
-        targetPositionTime.direction = distance/abs(distance);
+        if (distance == 0) {
+            targetPositionTime.direction = lastPositionTime.direction;
+        } else {
+            targetPositionTime.direction = distance/abs(distance);
+        }
         bool sameDirection = lastPositionTime.direction == targetPositionTime.direction;
         if (!sameDirection && stepper->isRunning()){
             vTaskDelay(1);


### PR DESCRIPTION
hi. it's Rei

Ordered my OSSM last week and was reading through the streaming code before wiring up my own BLE controller. While tracing how stream commands turn into motion, I hit a spot that looked off.

What I found:

In `src/ossm/streaming/streaming.cpp` the streaming task computes direction as:
```
int16_t distance = targetPositionTime.position - lastPositionTime.position;
targetPositionTime.direction = distance / abs(distance);
```
When two consecutive commands share the same position, distance is 0, so this evaluates 0 / 0. pos is valid 0..100 with no de-dup anywhere, so a plain stream:50:100 twice in a row reaches it. The resulting direction is unspecified, which also feeds the sameDirection check right after.

Separately, lastPositionTime is declared with no initializer:

```PositionTime lastPositionTime;```

so the first command compares against uninitialized position/direction.

Fix: 
- Initialize lastPositionTime to a zero/neutral state.
- When distance == 0, keep the previous direction instead of dividing.
```
int16_t distance = targetPositionTime.position - lastPositionTime.position;
if (distance == 0) {
    targetPositionTime.direction = lastPositionTime.direction;
} else {
    targetPositionTime.direction = distance / abs(distance);
}
```
Non-zero moves compute direction exactly as before; this only changes the previously-undefined same-position case.

Tested in local environment. (the machine itself is not arrived yet so)

Let me know if I'm missing something.