### PR TITLE
RAD-2119: Migrate OTA from CloudFront/Bubble to Supabase

### DIFF
--- a/Software/src/structs/Version.h
+++ b/Software/src/structs/Version.h
@@ -1,0 +1,20 @@
+#ifndef OSSM_VERSION_STRUCT_H
+#define OSSM_VERSION_STRUCT_H
+
+#include "constants/Version.h"
+
+// Numeric view of the firmware version baked into this build, used for the
+// client-side update comparison in utils/update.h.
+struct Version {
+    int major = 0;
+    int minor = 0;
+    int patch = 0;
+};
+
+inline const Version currentVersion = {
+    .major = MAJOR_VERSION,
+    .minor = MINOR_VERSION,
+    .patch = PATCH_VERSION,
+};
+
+#endif  // OSSM_VERSION_STRUCT_H

--- a/Software/src/utils/update.h
+++ b/Software/src/utils/update.h
@@ -2,101 +2,141 @@
 #define SOFTWARE_UPDATE_H
 
 #include <Arduino.h>
-#include <HTTPClient.h>
-#include <HTTPUpdate.h>
+#include <WiFi.h>
+#include <esp_crt_bundle.h>
+#include <esp_http_client.h>
+#include <esp_https_ota.h>
+#include <esp_log.h>
+#include <esp_system.h>
 
 #include "ArduinoJson.h"
 #include "constants/LogTags.h"
+#include "structs/Version.h"
 
-#ifndef SW_VERSION
-#define SW_VERSION "0.0.0"
-#endif
+// Firmware update host. Single source of truth shared with the webflasher: the
+// Supabase "production" channel. The device fetches version.json, decides for
+// itself whether a newer build exists, and downloads firmware.bin from the same
+// place over validated HTTPS. To move hosts later (e.g. GitHub Pages), only
+// OTA_BASE_URL changes.
+namespace OtaConfig {
+static const char *OTA_BASE_URL =
+    "https://acjajruwevyyatztbkdf.supabase.co/storage/v1/object/public/"
+    "ossm-firmware/";
+static const char *PRODUCTION_PATH = "production/";
+static const char *VERSION_JSON = "version.json";
+static const char *FIRMWARE_BIN = "firmware.bin";
+}  // namespace OtaConfig
 
-static auto isUpdateAvailable = []() {
-    // check if we're online
+// Minimal HTTPS GET using the ESP-IDF client with full certificate-bundle
+// validation (never setInsecure — that masks TLS-memory issues in prod).
+// Returns the HTTP status code, or -1 on transport failure; the response body
+// is written to *out when provided.
+static int otaHttpGet(const String &url, String *out, int timeoutMs) {
+    esp_http_client_config_t config = {};
+    config.url = url.c_str();
+    config.timeout_ms = timeoutMs;
+    config.crt_bundle_attach = esp_crt_bundle_attach;
+
+    esp_http_client_handle_t client = esp_http_client_init(&config);
+    if (client == nullptr) {
+        return -1;
+    }
+
+    int status = -1;
+    if (esp_http_client_open(client, 0) == ESP_OK) {
+        esp_http_client_fetch_headers(client);
+        status = esp_http_client_get_status_code(client);
+
+        if (out != nullptr) {
+            out->clear();
+            char buffer[256];
+            int read = 0;
+            while ((read = esp_http_client_read(client, buffer,
+                                                sizeof(buffer) - 1)) > 0) {
+                buffer[read] = '\0';
+                *out += buffer;
+            }
+        }
+        esp_http_client_close(client);
+    }
+
+    esp_http_client_cleanup(client);
+    return status;
+}
+
+// Fetch the published version for the production channel and compare it against
+// the firmware baked into this build. On any failure we return currentVersion
+// so a flaky network never triggers a spurious update or a crash.
+static Version getRemoteVersion() {
     if (WiFiClass::status() != WL_CONNECTED) {
         ESP_LOGD(UPDATE_TAG, "Not connected to WiFi");
-        return false;
+        return currentVersion;
     }
 
-    String serverNameBubble =
-        "http://d2g4f7zewm360.cloudfront.net/check-for-ossm-update";  // live
-                                                                      // url
-#ifdef VERSIONDEV
-    serverNameBubble =
-        "http://d2oq8yqnezqh3r.cloudfront.net/check-for-ossm-update";  // version-test
-#endif
+    String url = String(OtaConfig::OTA_BASE_URL) + OtaConfig::PRODUCTION_PATH +
+                 OtaConfig::VERSION_JSON;
+    ESP_LOGD(UPDATE_TAG, "Checking for updates at %s", url.c_str());
 
-#ifdef VERSIONSTAGING
-    serverNameBubble =
-        "http://d2oq8yqnezqh3r.cloudfront.net/check-for-ossm-update";  // version-test
-#endif
-
-    ESP_LOGD(UPDATE_TAG, "Checking for updates at %s",
-             serverNameBubble.c_str());
-
-    // Making the POST request to the bubble server
-    HTTPClient http;
-    WiFiClient client;
-    http.begin(client, serverNameBubble);
-    http.addHeader("Content-Type", "application/json");
-    JsonDocument doc;
-    // Add values in the document
-    doc["ossmSwVersion"] = SW_VERSION;
-    String requestBody;
-    serializeJson(doc, requestBody);
-    int httpResponseCode = http.POST(requestBody);
-
-    // Reading payload
-    String payload = "{}";
-    payload = http.getString();
-    ESP_LOGD(UPDATE_TAG, "HTTP Response code: %d", httpResponseCode);
-    JsonDocument bubbleResponse;
-    deserializeJson(bubbleResponse, payload);
-    bool response_needUpdate = bubbleResponse["response"]["needUpdate"];
-
-    ESP_LOGD("UTILS", "Payload: %s", payload.c_str());
-
-    if (httpResponseCode <= 0) {
-        ESP_LOGD("UTILS", "Failed to reach update server");
+    String payload;
+    int status = otaHttpGet(url, &payload, 15000);
+    if (status != 200) {
+        ESP_LOGD(UPDATE_TAG, "Update check failed (HTTP %d)", status);
+        return currentVersion;
     }
-    http.end();
-    client.stop();
-    return response_needUpdate;
+
+    ESP_LOGD(UPDATE_TAG, "version.json: %s", payload.c_str());
+
+    // version.json: { "version": "1.0.28", "major": 1, "minor": 0, "patch": 28 }
+    JsonDocument version;
+    DeserializationError error = deserializeJson(version, payload);
+    if (error) {
+        ESP_LOGD(UPDATE_TAG, "Failed to parse version.json: %s", error.c_str());
+        return currentVersion;
+    }
+
+    return {
+        .major = version["major"] | currentVersion.major,
+        .minor = version["minor"] | currentVersion.minor,
+        .patch = version["patch"] | currentVersion.patch,
+    };
+}
+
+// State-machine guard ("update.checking" -> "update.updating"). Only true when
+// the remote build is strictly newer, which prevents downgrades.
+static auto isUpdateAvailable = []() {
+    Version remoteVersion = getRemoteVersion();
+    if (remoteVersion.major != currentVersion.major) {
+        return remoteVersion.major > currentVersion.major;
+    }
+    if (remoteVersion.minor != currentVersion.minor) {
+        return remoteVersion.minor > currentVersion.minor;
+    }
+    return remoteVersion.patch > currentVersion.patch;
 };
 
+// State-machine action: download + flash the production firmware over HTTPS,
+// then reboot into it. esp_https_ota does not auto-reboot, so we restart here
+// on success (the Arduino httpUpdate path used to reboot implicitly).
 auto updateOSSM = []() {
-    // check if we're online
+    String url = String(OtaConfig::OTA_BASE_URL) + OtaConfig::PRODUCTION_PATH +
+                 OtaConfig::FIRMWARE_BIN;
+    ESP_LOGI(UPDATE_TAG, "Starting OTA from %s (free heap: %lu)", url.c_str(),
+             (unsigned long)esp_get_free_heap_size());
 
-    WiFiClient client;
-    String url = "http://d2sy3zdr3r1gt5.cloudfront.net/firmware.bin";
+    esp_http_client_config_t httpConfig = {};
+    httpConfig.url = url.c_str();
+    httpConfig.timeout_ms = 30000;
+    httpConfig.buffer_size = 4096;
+    httpConfig.buffer_size_tx = 1024;
+    httpConfig.crt_bundle_attach = esp_crt_bundle_attach;
 
-#ifdef VERSIONDEV
-    url = "http://d2sy3zdr3r1gt5.cloudfront.net/firmware-dev.bin";
-#endif
-#ifdef VERSIONSTAGING
-    url = "http://d2sy3zdr3r1gt5.cloudfront.net/firmware-dev.bin";
-#endif
-
-    t_httpUpdate_return ret = httpUpdate.update(client, url);
-
-    switch (ret) {
-        case HTTP_UPDATE_FAILED:
-            ESP_LOGD("UTILS", "HTTP_UPDATE_FAILED Error (%d): %s\n",
-                     httpUpdate.getLastError(),
-                     httpUpdate.getLastErrorString().c_str());
-            break;
-
-        case HTTP_UPDATE_NO_UPDATES:
-            ESP_LOGD("UTILS", "HTTP_UPDATE_NO_UPDATES");
-            break;
-
-        case HTTP_UPDATE_OK:
-            ESP_LOGD("UTILS", "HTTP_UPDATE_OK");
-            break;
+    esp_err_t ret = esp_https_ota(&httpConfig);
+    if (ret == ESP_OK) {
+        ESP_LOGI(UPDATE_TAG, "OTA succeeded, restarting...");
+        esp_restart();
     }
 
-    client.stop();
+    ESP_LOGE(UPDATE_TAG, "OTA failed: %s", esp_err_to_name(ret));
 };
 
 #endif  // SOFTWARE_UPDATE_H


### PR DESCRIPTION
The WiFi OTA fetched firmware from a legacy CloudFront origin and asked a Bubble endpoint whether to update. That origin is no longer maintained, so devices updated to a stale 1.0.16 and newer units could be downgraded.

Rewrite update.h to fetch version.json from the Supabase production channel (the same source the webflasher uses), compare the version on-device, and download firmware.bin over validated HTTPS via esp_https_ota. The device only updates when the remote build is strictly newer, which removes the downgrade.

Add structs/Version.h for the numeric version used in the comparison. The state machine guard and action (isUpdateAvailable, updateOSSM) keep their names, so no state machine changes are needed.