### PR TITLE
Mirror production firmware to the legacy CloudFront path on promotion

### DIFF
--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # required for the AWS OIDC login (legacy CloudFront mirror)
 
 jobs:
   release-production:
@@ -53,8 +54,23 @@ jobs:
           # Upload version.json
           supabase storage cp ./firmware/version.json "ss:///ossm-firmware/production/version.json" --content-type "application/json" --cache-control "no-cache" --experimental
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-2
+
+      - name: Mirror firmware to legacy CloudFront origin (S3)
+        run: |
+          # Old WiFi-OTA devices (e.g. 1.0.16) download from the legacy CloudFront
+          # path, not Supabase. Refresh it on every prod promotion so that fleet
+          # stays current. Bucket "ossm-update" is the origin behind
+          # d2sy3zdr3r1gt5.cloudfront.net (confirmed via matching x-amz-version-id).
+          aws s3 cp ./firmware/firmware.bin s3://ossm-update/firmware.bin --acl public-read
+
       - name: Summary
         run: |
           echo "✅ Released v${{ steps.get_version.outputs.version }} to production channel"
           echo ""
-          echo "Firmware URL: https://acjajruwevyyatztbkdf.supabase.co/storage/v1/object/public/ossm-firmware/production/"
+          echo "Supabase: https://acjajruwevyyatztbkdf.supabase.co/storage/v1/object/public/ossm-firmware/production/"
+          echo "Legacy:   https://d2sy3zdr3r1gt5.cloudfront.net/firmware.bin"


### PR DESCRIPTION
Old WiFi-OTA devices download firmware from the legacy CloudFront/S3 path (bucket ossm-update), not Supabase. That path was updated by hand and got forgotten, freezing the fleet at an old build. Make the legacy upload an automatic step of Release Alpha as Production so it stays in sync on every promotion and cannot silently drift again.

After the Supabase production upload, log into AWS via the OIDC role and aws s3 cp the firmware to s3://ossm-update/firmware.bin. The Supabase publish runs first, so if the S3 step fails (missing role permission) production is still correct and the failure is non-destructive.