### PR TITLE
Kareem/rad 2140 stroke engine drifts into the back endstop on repeated ble

### DIFF
--- a/Software/lib/StrokeEngine/src/StrokeEngine.cpp
+++ b/Software/lib/StrokeEngine/src/StrokeEngine.cpp
@@ -375,7 +375,7 @@ void StrokeEngine::enableAndHome(endstopProperties *endstop, float speed) {
 #endif
 }
 
-void StrokeEngine::thisIsHome(float speed) {
+void StrokeEngine::thisIsHome(float speed, bool resetOrigin) {
     // set homeing speed
     _homeingSpeed = speed * _motor->stepsPerMillimeter;
 
@@ -383,10 +383,17 @@ void StrokeEngine::thisIsHome(float speed) {
         // Enable _servo
         _servo->enableOutputs();
 
-        // Translate current position
-        _servo->setCurrentPosition(abs(_servo->getCurrentPosition())-
-                                       _motor->stepsPerMillimeter *
+        // Only (re-)establish the home origin on a genuine fresh physical home.
+        // On a re-entry (resetOrigin == false) the carriage was NOT re-homed,
+        // so the position counter is already valid in the established frame;
+        // re-basing it here is what accumulated ~6 mm of drift per entry.
+        if (resetOrigin) {
+            // Home == -keepoutBoundary, a constant independent of the current
+            // counter. (The previous abs()-of-current-position re-based the
+            // origin off wherever the carriage happened to sit.)
+            _servo->setCurrentPosition(-_motor->stepsPerMillimeter *
                                        _physics->keepoutBoundary);
+        }
 
         // Change state
         _isHomed = true;

--- a/Software/lib/StrokeEngine/src/StrokeEngine.h
+++ b/Software/lib/StrokeEngine/src/StrokeEngine.h
@@ -266,7 +266,7 @@ class StrokeEngine {
                     Defaults to 5.0 mm/s
     */
     /**************************************************************************/
-    void thisIsHome(float speed = 5.0);
+    void thisIsHome(float speed = 5.0, bool resetOrigin = true);
 
     /**************************************************************************/
     /*!

--- a/Software/src/ossm/homing/homing.cpp
+++ b/Software/src/ossm/homing/homing.cpp
@@ -46,6 +46,7 @@ static void startHomingTask(void *pvParameters) {
 #ifdef AJ_DEVELOPMENT_HARDWARE
     stepper->setCurrentPosition(0);
     stepper->forceStopAndNewPosition(0);
+    stepperFrame = StepperFrame::Native;  // counter re-zeroed at home rest
     stateMachine->process_event(Done{});
     vTaskDelete(nullptr);
     return;
@@ -121,6 +122,9 @@ static void startHomingTask(void *pvParameters) {
 
         stepper->setCurrentPosition(0);
         stepper->forceStopAndNewPosition(0);
+        // The counter was just re-zeroed at the homed rest position: the
+        // shared frame is Native again by definition.
+        stepperFrame = StepperFrame::Native;
 
         int32_t goToPosition = homing_logic::calculatePostHomingPosition(
             sign, calibration.measuredStrokeSteps,

--- a/Software/src/ossm/simple_penetration/simple_penetration.cpp
+++ b/Software/src/ossm/simple_penetration/simple_penetration.cpp
@@ -19,9 +19,11 @@ namespace simple_penetration {
 static void startSimplePenetrationTask(void *pvParameters) {
     // Own the shared stepper config at mode entry: a preceding StrokeEngine
     // session leaves the shared DIR polarity inverted (StrokeEngine::begin)
-    // and only homing resets it. This mode's targets assume the homing
-    // frame's normal polarity, so an inherited inverted latch runs every
-    // stroke physically reversed (into the back plate). Set it explicitly.
+    // and the counter in the StrokeEngine frame; only homing resets them.
+    // This mode's targets are native-frame absolutes with normal polarity,
+    // so reconcile both explicitly (exact math, no motion) — otherwise every
+    // stroke runs physically reversed and/or displaced into a hard stop.
+    stepperTranslateFrame(StepperFrame::Native);
     stepper->setDirectionPin(Pins::Driver::motorDirectionPin, false);
     stepper->enableOutputs();
 

--- a/Software/src/ossm/simple_penetration/simple_penetration.cpp
+++ b/Software/src/ossm/simple_penetration/simple_penetration.cpp
@@ -17,6 +17,14 @@ using namespace sml;
 namespace simple_penetration {
 
 static void startSimplePenetrationTask(void *pvParameters) {
+    // Own the shared stepper config at mode entry: a preceding StrokeEngine
+    // session leaves the shared DIR polarity inverted (StrokeEngine::begin)
+    // and only homing resets it. This mode's targets assume the homing
+    // frame's normal polarity, so an inherited inverted latch runs every
+    // stroke physically reversed (into the back plate). Set it explicitly.
+    stepper->setDirectionPin(Pins::Driver::motorDirectionPin, false);
+    stepper->enableOutputs();
+
     int fullStrokeCount = 0;
     static int32_t targetPosition = 0;
 

--- a/Software/src/ossm/state/actions.cpp
+++ b/Software/src/ossm/state/actions.cpp
@@ -188,6 +188,7 @@ void ossmDrawPairingSuccess() {
 
 void ossmSetHomed() {
     calibration.isHomed = true;
+    calibration.justHomed = true;
 }
 
 void ossmSetNotHomed() {

--- a/Software/src/ossm/state/calibration.h
+++ b/Software/src/ossm/state/calibration.h
@@ -12,6 +12,10 @@ struct CalibrationState {
     float measuredStrokeSteps = 0;
     bool isHomed = false;
     bool isForward = true;  // Homing direction
+    // True for exactly one StrokeEngine entry immediately after a physical
+    // home; consumed (cleared) by startStrokeEngineTask. Gates whether the
+    // StrokeEngine origin may be (re-)adopted from the current position.
+    bool justHomed = false;
 };
 
 extern CalibrationState calibration;

--- a/Software/src/ossm/streaming/streaming.cpp
+++ b/Software/src/ossm/streaming/streaming.cpp
@@ -21,8 +21,9 @@ namespace streaming {
 
 static void startStreamingTask(void *pvParameters) {
     // Own the shared stepper config at mode entry (see simple_penetration.cpp:
-    // StrokeEngine leaves the shared DIR polarity inverted; this mode's
-    // targets assume the homing frame's normal polarity).
+    // StrokeEngine leaves the shared DIR polarity inverted and the counter in
+    // its own frame; this mode's targets are native-frame absolutes).
+    stepperTranslateFrame(StepperFrame::Native);
     stepper->setDirectionPin(Pins::Driver::motorDirectionPin, false);
     stepper->enableOutputs();
 

--- a/Software/src/ossm/streaming/streaming.cpp
+++ b/Software/src/ossm/streaming/streaming.cpp
@@ -20,6 +20,12 @@ using namespace sml;
 namespace streaming {
 
 static void startStreamingTask(void *pvParameters) {
+    // Own the shared stepper config at mode entry (see simple_penetration.cpp:
+    // StrokeEngine leaves the shared DIR polarity inverted; this mode's
+    // targets assume the homing frame's normal polarity).
+    stepper->setDirectionPin(Pins::Driver::motorDirectionPin, false);
+    stepper->enableOutputs();
+
     auto isInCorrectState = []() {
         return stateMachine->is("streaming"_s) ||
                stateMachine->is("streaming.preflight"_s) ||

--- a/Software/src/ossm/stroke_engine/stroke_engine.cpp
+++ b/Software/src/ossm/stroke_engine/stroke_engine.cpp
@@ -28,8 +28,18 @@ static void startStrokeEngineTask(void *pvParameters) {
         .keepoutBoundary = 6.0};
     SettingPercents lastSetting = settings;
 
+    // Adopt the StrokeEngine origin only when entering right after a real
+    // physical home (justHomed) AND the carriage is actually at the homed rest
+    // position (counter ~0). On a go:menu re-entry neither holds, so we
+    // preserve the existing counter and skip the re-base that used to
+    // accumulate ~6 mm of drift per entry.
+    constexpr int32_t HOME_TOL = 40;  // steps (~2 mm at 20 steps/mm)
+    bool atHome = calibration.justHomed &&
+                  (abs(stepper->getCurrentPosition()) < HOME_TOL);
+    calibration.justHomed = false;
+
     Stroker.begin(&strokingMachine, &servoMotor, stepper);
-    Stroker.thisIsHome();
+    Stroker.thisIsHome(5.0f, atHome);
 
     Stroker.setSensation(calculateSensation(settings.sensation), true);
 

--- a/Software/src/ossm/stroke_engine/stroke_engine.cpp
+++ b/Software/src/ossm/stroke_engine/stroke_engine.cpp
@@ -38,6 +38,18 @@ static void startStrokeEngineTask(void *pvParameters) {
                   (abs(stepper->getCurrentPosition()) < HOME_TOL);
     calibration.justHomed = false;
 
+    if (atHome) {
+        // thisIsHome() below (re-)defines the origin at -keepout: the counter
+        // is being re-established, not translated.
+        stepperFrame = StepperFrame::StrokeEngine;
+    } else {
+        // Cross-mode entry (e.g. home -> SimplePenetration -> go:menu ->
+        // here): the counter is still a native-frame value; translate it into
+        // the StrokeEngine frame exactly (no motion). Same-mode re-entry is a
+        // no-op (frame already StrokeEngine) and keeps the counter as-is.
+        stepperTranslateFrame(StepperFrame::StrokeEngine);
+    }
+
     Stroker.begin(&strokingMachine, &servoMotor, stepper);
     Stroker.thisIsHome(5.0f, atHome);
 

--- a/Software/src/services/stepper.cpp
+++ b/Software/src/services/stepper.cpp
@@ -1,8 +1,23 @@
 #include "stepper.h"
 
+#include "constants/Config.h"
+
 FastAccelStepperEngine stepperEngine = FastAccelStepperEngine();
 FastAccelStepper *stepper = nullptr;
 class StrokeEngine Stroker;
+StepperFrame stepperFrame = StepperFrame::Native;
+
+void stepperTranslateFrame(StepperFrame to) {
+    if (stepperFrame == to) return;
+    if (stepper == nullptr) return;
+    // Mirror map between the two frames. The keepout must match
+    // strokingMachine.keepoutBoundary (6 mm) in stroke_engine.cpp.
+    constexpr int32_t keepoutSteps =
+        static_cast<int32_t>(6.0f * Config::Driver::stepsPerMM);
+    stepper->setCurrentPosition(
+        -(stepper->getCurrentPosition() + keepoutSteps));
+    stepperFrame = to;
+}
 
 void initStepper() {
     stepperEngine.init();

--- a/Software/src/services/stepper.h
+++ b/Software/src/services/stepper.h
@@ -9,6 +9,25 @@ extern FastAccelStepperEngine stepperEngine;
 extern FastAccelStepper *stepper;
 extern class StrokeEngine Stroker;
 
+// ── Shared-counter coordinate frame ─────────────────────────────────────
+// One position counter is shared by every mode, expressed in one of two
+// frames:
+//  • Native — homing / SimplePenetration / Streaming: counter 0 at the
+//    homed rest position, extension = negative counts, DIR polarity normal.
+//  • StrokeEngine — counter = extension − keepout (home rest reads
+//    −keepout), extension = positive counts, DIR polarity inverted
+//    (StrokeEngine::begin applies it, thisIsHome anchors it).
+// The frames are exact mirror images: c_other = −(c + keepout_steps), the
+// same formula in both directions. Homing re-establishes Native when it
+// zeroes the counter; every mode entry must ensure the counter is in ITS
+// frame before commanding motion.
+enum class StepperFrame { Native, StrokeEngine };
+extern StepperFrame stepperFrame;
+
+// Translate the shared counter into `to` (exact math, no motion). No-op
+// when already in that frame. Call only with the motor stopped.
+void stepperTranslateFrame(StepperFrame to);
+
 void initStepper();
 
 #endif  // SOFTWARE_STEPPER_H

--- a/Software/test/test_hw_regressions/main.cpp
+++ b/Software/test/test_hw_regressions/main.cpp
@@ -1,0 +1,308 @@
+/**
+ * Hardware Regression Tests — shared-stepper state across mode switches
+ *
+ * Run:  pio test -e hw_test -f test_hw_regressions
+ *
+ * WARNING: The motor WILL move: boot homing (~10 s) plus one short (~32 mm)
+ *          positioning move in test 1. Keep the rail clear, no attachment,
+ *          and the SPEED KNOB AT ZERO (preflight requires it, and it keeps
+ *          both operation modes motionless during the tests).
+ *
+ * These tests pin down three real field bugs. Each is written so that it
+ * FAILS on the pre-fix firmware (triggering/detecting the bug from counter
+ * or config state — no crash required) and PASSES on the fixed firmware:
+ *
+ *  1. StrokeEngine re-entry origin drift
+ *     Trigger: enter StrokeEngine → exit via the BLE go:menu path
+ *     (ReturnToMenu: no re-home, isHomed stays true) → re-enter.
+ *     Broken firmware re-bases the origin off the parked position in
+ *     thisIsHome() (counter := abs(parked) − 120), shifting the machine's
+ *     working window every entry until it reaches the physical end stop.
+ *     Fixed firmware preserves the counter on re-entry (adopts the origin
+ *     only once per physical home).
+ *     Assert: counter after re-entry == parked counter (±40 steps).
+ *
+ *  2. SimplePenetration inherits StrokeEngine's inverted DIR polarity
+ *     Trigger: StrokeEngine session → go:menu → SimplePenetration (no
+ *     re-home in between). StrokeEngine::begin() flips the SHARED stepper
+ *     direction polarity (directionPinHighCountsUp() == true) and only a
+ *     homing pass resets it. Broken SimplePenetration never sets its own
+ *     polarity, so it runs physically REVERSED — every stroke drives into
+ *     the back plate. Fixed SimplePenetration sets the polarity explicitly
+ *     at task entry.
+ *     Assert: directionPinHighCountsUp() == false once SimplePenetration
+ *     is running (read with the motor stationary — knob at zero).
+ *
+ *  3. Cross-mode switches leave the counter in the previous mode's frame
+ *     Trigger: StrokeEngine parked off-home → go:menu → SimplePenetration
+ *     (and the mirror direction). The two frames are exact mirror images
+ *     (native: 0 at home rest, extension negative; StrokeEngine: home rest
+ *     at −keepout, extension positive). Broken firmware hands the next mode
+ *     the raw previous-frame counter, displacing its whole stroke window
+ *     (worst case past a physical stop). Fixed firmware translates the
+ *     counter exactly at every mode entry (stepperTranslateFrame).
+ *     Assert: after parking at StrokeEngine counter 530 (= 650 steps out
+ *     from home rest), SimplePenetration reads −650 for the same physical
+ *     spot, and a StrokeEngine re-entry reads 530 again.
+ */
+
+#include <Arduino.h>
+#include <unity.h>
+#include "esp_log.h"
+
+#include "constants/Menu.h"
+#include "ossm/Events.h"
+#include "ossm/OSSM.h"
+#include "ossm/state/actions.h"
+#include "ossm/state/calibration.h"
+#include "ossm/state/menu.h"
+#include "ossm/state/state.h"
+#include "services/board.h"
+#include "services/display.h"
+#include "services/stepper.h"
+
+namespace sml = boost::sml;
+using namespace sml;
+
+void setUp(void) {}
+void tearDown(void) {
+    ossmEmergencyStop();
+}
+
+static constexpr uint32_t HOMING_TIMEOUT_MS = 30000;
+
+// Steps tolerance for counter asserts. The buggy re-base shifts by exactly
+// 120 steps (6 mm), so ±40 cleanly separates "preserved" from "re-based".
+static constexpr int32_t TOL_STEPS = 40;
+
+// Expected origin right after a fresh-home StrokeEngine entry:
+// 0 − keepoutBoundary(6 mm) × stepsPerMm(20) = −120.
+static constexpr int32_t FRESH_ORIGIN = -120;
+
+// ─── Helpers ───────────────────────────────────────────────
+
+static bool waitMenuIdle(uint32_t timeoutMs) {
+    uint32_t start = millis();
+    while (!stateMachine->is("menu.idle"_s)) {
+        if (millis() - start > timeoutMs) return false;
+        vTaskDelay(pdMS_TO_TICKS(100));
+    }
+    return true;
+}
+
+static bool waitStrokeEngineIdle(uint32_t timeoutMs) {
+    uint32_t start = millis();
+    while (!stateMachine->is("strokeEngine.idle"_s)) {
+        if (millis() - start > timeoutMs) return false;
+        vTaskDelay(pdMS_TO_TICKS(50));
+    }
+    return true;
+}
+
+static bool waitSimplePenIdle(uint32_t timeoutMs) {
+    uint32_t start = millis();
+    while (!stateMachine->is("simplePenetration.idle"_s)) {
+        if (millis() - start > timeoutMs) return false;
+        vTaskDelay(pdMS_TO_TICKS(50));
+    }
+    return true;
+}
+
+static void selectMenuOption(Menu option) {
+    menuState.currentOption = option;
+    stateMachine->process_event(ButtonPress{});
+    vTaskDelay(pdMS_TO_TICKS(200));
+}
+
+/** Exit the current mode via the BLE go:menu path (ReturnToMenu). This is
+ *  the path a BLE disconnect / dashboard uses: emergencyStop only, NO
+ *  setNotHomed, so no physical re-home happens on the next entry. */
+static bool bleReturnToMenu() {
+    stateMachine->process_event(ReturnToMenu{});
+    return waitMenuIdle(3000);
+}
+
+// ─── Test 1: StrokeEngine re-entry origin drift ────────────
+
+void test_strokeengine_reentry_preserves_position(void) {
+    TEST_ASSERT_TRUE_MESSAGE(stateMachine->is("menu.idle"_s),
+                             "Pre-condition: must be in menu.idle");
+    TEST_ASSERT_TRUE_MESSAGE(calibration.isHomed,
+                             "Pre-condition: must be homed");
+
+    // Entry 1 — fresh home: the origin must be adopted exactly once, at -120.
+    selectMenuOption(Menu::StrokeEngine);
+    TEST_ASSERT_TRUE_MESSAGE(
+        waitStrokeEngineIdle(3000),
+        "StrokeEngine did not reach idle - is the speed knob at ZERO?");
+    vTaskDelay(pdMS_TO_TICKS(900));  // let the task run begin()+thisIsHome()
+    int32_t origin = stepper->getCurrentPosition();
+    TEST_ASSERT_INT32_WITHIN_MESSAGE(
+        TOL_STEPS, FRESH_ORIGIN, origin,
+        "Fresh-home StrokeEngine entry should adopt origin -120");
+
+    // Park the carriage off-home with a short blocking move inside the
+    // engine's safe window [0, maxStep] (~32 mm; window is >=38 mm even at
+    // the minimum calibrated stroke). The engine task is idle at speed 0.
+    stepper->setSpeedInHz(1000);
+    stepper->setAcceleration(20000);
+    stepper->moveTo(origin + 650, true);
+    int32_t parked = stepper->getCurrentPosition();
+
+    // Exit via the BLE go:menu path: no re-home, isHomed stays true.
+    TEST_ASSERT_TRUE_MESSAGE(bleReturnToMenu(),
+                             "ReturnToMenu should land in menu.idle");
+    TEST_ASSERT_TRUE_MESSAGE(calibration.isHomed,
+                             "BLE exit must keep isHomed true (no re-home)");
+
+    // Entry 2 — re-entry without a physical re-home. The counter is already
+    // valid; it must be PRESERVED. Broken firmware re-bases the origin:
+    // counter := abs(parked) - 120, i.e. a 120-step shift on every entry.
+    selectMenuOption(Menu::StrokeEngine);
+    TEST_ASSERT_TRUE_MESSAGE(
+        waitStrokeEngineIdle(3000),
+        "StrokeEngine re-entry did not reach idle - is the speed knob at ZERO?");
+    vTaskDelay(pdMS_TO_TICKS(900));
+    int32_t after = stepper->getCurrentPosition();
+    TEST_ASSERT_INT32_WITHIN_MESSAGE(
+        TOL_STEPS, parked, after,
+        "ORIGIN DRIFT: re-entry re-based the origin off the parked position "
+        "(expected the counter preserved; broken firmware yields parked-120)");
+
+    TEST_ASSERT_TRUE(bleReturnToMenu());
+}
+
+// ─── Test 2: SimplePen inherits inverted DIR polarity ──────
+
+void test_simplepen_owns_direction_after_strokeengine(void) {
+    // Self-recover to menu.idle: when a prior test fails, Unity longjmps out
+    // at the failing assert and that test's trailing cleanup never runs,
+    // leaving the machine mid-mode. Recover so this test still exercises and
+    // reports ITS OWN bug instead of dying on a stale pre-condition.
+    if (!stateMachine->is("menu.idle"_s)) {
+        stateMachine->process_event(ReturnToMenu{});
+        waitMenuIdle(3000);
+    }
+    TEST_ASSERT_TRUE_MESSAGE(stateMachine->is("menu.idle"_s),
+                             "Pre-condition: must be in menu.idle");
+    TEST_ASSERT_TRUE_MESSAGE(calibration.isHomed,
+                             "Pre-condition: must be homed");
+
+    // StrokeEngine session: begin() flips the SHARED direction polarity to
+    // inverted. Knob at zero -> the engine idles, no motion.
+    selectMenuOption(Menu::StrokeEngine);
+    TEST_ASSERT_TRUE_MESSAGE(
+        waitStrokeEngineIdle(3000),
+        "StrokeEngine did not reach idle - is the speed knob at ZERO?");
+    vTaskDelay(pdMS_TO_TICKS(900));
+    TEST_ASSERT_TRUE_MESSAGE(
+        stepper->directionPinHighCountsUp(),
+        "Sanity: a StrokeEngine session should leave the shared DIR polarity "
+        "inverted (this is the state the next mode inherits)");
+
+    // BLE go:menu exit (no re-home), then enter SimplePenetration.
+    TEST_ASSERT_TRUE_MESSAGE(bleReturnToMenu(),
+                             "ReturnToMenu should land in menu.idle");
+    selectMenuOption(Menu::SimplePenetration);
+    TEST_ASSERT_TRUE_MESSAGE(
+        waitSimplePenIdle(3000),
+        "SimplePenetration did not reach idle - is the speed knob at ZERO?");
+    vTaskDelay(pdMS_TO_TICKS(600));  // let the task's entry code run
+
+    // SimplePenetration's targets assume the homing frame's NORMAL polarity
+    // (directionPinHighCountsUp == false). Broken firmware inherits
+    // StrokeEngine's inverted latch, so every stroke runs physically
+    // REVERSED - the back-plate slam. Read the live latch, motor stationary:
+    TEST_ASSERT_FALSE_MESSAGE(
+        stepper->directionPinHighCountsUp(),
+        "DIR INVERSION: SimplePenetration is running on StrokeEngine's "
+        "inverted direction polarity - its motion would be physically "
+        "reversed (drives into the back plate)");
+
+    TEST_ASSERT_TRUE(bleReturnToMenu());
+}
+
+// ─── Test 3: cross-mode counter frame translation ──────────
+
+void test_cross_mode_frame_translation(void) {
+    // Self-recover to menu.idle (see test 2).
+    if (!stateMachine->is("menu.idle"_s)) {
+        stateMachine->process_event(ReturnToMenu{});
+        waitMenuIdle(3000);
+    }
+    TEST_ASSERT_TRUE_MESSAGE(stateMachine->is("menu.idle"_s),
+                             "Pre-condition: must be in menu.idle");
+    TEST_ASSERT_TRUE_MESSAGE(calibration.isHomed,
+                             "Pre-condition: must be homed");
+
+    // StrokeEngine session; park deterministically: first at the home rest
+    // (-120 in the StrokeEngine frame), then 650 steps (32.5 mm) out. Safe
+    // on any rig (minimum calibrated stroke is 50 mm).
+    selectMenuOption(Menu::StrokeEngine);
+    TEST_ASSERT_TRUE_MESSAGE(
+        waitStrokeEngineIdle(3000),
+        "StrokeEngine did not reach idle - is the speed knob at ZERO?");
+    vTaskDelay(pdMS_TO_TICKS(900));
+    stepper->setSpeedInHz(1000);
+    stepper->setAcceleration(20000);
+    stepper->moveTo(-120, true);  // physical home rest
+    stepper->moveTo(530, true);   // 650 steps out; StrokeEngine frame
+    TEST_ASSERT_INT32_WITHIN_MESSAGE(4, 530, stepper->getCurrentPosition(),
+                                     "Setup: park move did not complete");
+
+    // BLE exit -> SimplePenetration. Its targets are native-frame absolutes,
+    // so the SAME physical spot must read -(530 + 120) = -650 here. Broken
+    // firmware keeps the StrokeEngine-frame value (530): the whole stroke
+    // window would be displaced ~59 mm toward the FRONT stop.
+    TEST_ASSERT_TRUE_MESSAGE(bleReturnToMenu(),
+                             "ReturnToMenu should land in menu.idle");
+    selectMenuOption(Menu::SimplePenetration);
+    TEST_ASSERT_TRUE_MESSAGE(
+        waitSimplePenIdle(3000),
+        "SimplePenetration did not reach idle - is the speed knob at ZERO?");
+    vTaskDelay(pdMS_TO_TICKS(600));
+    TEST_ASSERT_INT32_WITHIN_MESSAGE(
+        40, -650, stepper->getCurrentPosition(),
+        "FRAME MISMATCH: SimplePenetration inherited a StrokeEngine-frame "
+        "counter - its stroke window is displaced toward the front stop");
+
+    // And the mirror direction: re-entering StrokeEngine (no re-home) must
+    // translate the native counter back: -(-650 + 120) = 530.
+    TEST_ASSERT_TRUE_MESSAGE(bleReturnToMenu(),
+                             "ReturnToMenu should land in menu.idle");
+    selectMenuOption(Menu::StrokeEngine);
+    TEST_ASSERT_TRUE_MESSAGE(waitStrokeEngineIdle(3000),
+                             "StrokeEngine re-entry did not reach idle");
+    vTaskDelay(pdMS_TO_TICKS(900));
+    TEST_ASSERT_INT32_WITHIN_MESSAGE(
+        40, 530, stepper->getCurrentPosition(),
+        "FRAME MISMATCH: StrokeEngine inherited a native-frame counter - "
+        "its pattern window is displaced");
+
+    TEST_ASSERT_TRUE(bleReturnToMenu());
+}
+
+// ─── Runner ─────────────────────────────────────────────────
+
+void setup() {
+    delay(2000);  // give serial monitor time to connect
+
+    esp_log_level_set("gpio", ESP_LOG_WARN);
+
+    initBoard();
+    initDisplay();
+
+    ossm = new OSSM();
+    initStateMachine();  // fires Done{} -> idle -> homing (motor WILL move)
+    waitMenuIdle(HOMING_TIMEOUT_MS);
+
+    UNITY_BEGIN();
+
+    RUN_TEST(test_strokeengine_reentry_preserves_position);
+    RUN_TEST(test_simplepen_owns_direction_after_strokeengine);
+    RUN_TEST(test_cross_mode_frame_translation);
+
+    UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
closes [RAD-2140](https://linear.app/researchanddesire/issue/RAD-2140/stroke-engine-drifts-into-the-back-endstop-on-repeated-ble-re-entry)

Fix StrokeEngine re-entry drift + related cross-mode stepper bugs (RAD-2140)

Fixes the reported StrokeEngine drift-into-the-endstop, plus two latent bugs in the same subsystem that share one root cause: operation modes share the stepper's direction and position state as mutable global state, but don't re-establish their own required state on entry — only a physical re-home reset it. All three surface on the BLE/menu mode-switch path that skips re-homing (a BLE disconnect auto-sends go:menu).

Bugs fixed (each an isolated commit):

StrokeEngine re-entry drift (the report) — re-entering via go:menu (no re-home) re-based the origin off the parked position every entry (thisIsHome did abs(current) − keepout), marching the stroke window ~6 mm/entry into the back endstop. → Adopt the origin once per physical home; preserve the counter on re-entry.
Reversed motion in SimplePenetration / Streaming — StrokeEngine::begin() inverts the shared direction pin (correct for itself); those modes never reset it, so after a StrokeEngine session they ran physically reversed — every stroke into the back plate. → Each mode sets its own direction polarity + enables outputs at entry.
Cross-mode coordinate-frame mismatch — the shared counter was left in the previous mode's frame after a switch, displacing the next mode's stroke window up to ~59 mm (front-stop risk). → Exact frame translation (c → −(c + keepout)) at each mode entry.
