### PR TITLE
RAD-2144: rebuild firmware registry from bucket contents instead of editing in place

### DIFF
--- a/.github/scripts/rebuild_registry.sh
+++ b/.github/scripts/rebuild_registry.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Rebuilds <BUCKET>/registry.json from the bucket's actual contents and uploads
+# it atomically. The registry is derived state: this script never reads the old
+# registry.json, so a corrupt, empty, or missing one cannot propagate. Safe to
+# run at any time; the last run to finish always converges on ground truth.
+#
+# Required env:
+#   SUPABASE_ACCESS_TOKEN  - platform token (sbp_...) or project service key
+#   SUPABASE_PROJECT_ID    - project ref
+set -euo pipefail
+
+BUCKET="ossm-firmware"
+# Release channels are published by the version/release workflows and are not
+# dev branches; the web flasher's Development dropdown must not list them.
+PROTECTED_CHANNELS=("master" "alpha" "production")
+BASE="https://${SUPABASE_PROJECT_ID}.supabase.co/storage/v1"
+LIST_LIMIT=1000
+
+# The storage REST API needs a project JWT. CI stores a platform access token
+# (sbp_...), so exchange it for the service_role key the same way the CLI does.
+if [[ "${SUPABASE_ACCESS_TOKEN}" == sbp_* ]]; then
+  STORAGE_KEY=$(curl -sf "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_ID}/api-keys?reveal=true" \
+      -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+    | jq -re '.[] | select(.name == "service_role") | .api_key')
+else
+  STORAGE_KEY="${SUPABASE_ACCESS_TOKEN}"
+fi
+
+# One-level listing. Prefix travels in the JSON body, so URL-encoded branch
+# names (kareem%2Fmy-branch) need no extra escaping. Folders have "id": null.
+list() {
+  curl -sf -X POST "${BASE}/object/list/${BUCKET}" \
+    -H "Authorization: Bearer ${STORAGE_KEY}" \
+    -H "apikey: ${STORAGE_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "{\"prefix\":\"$1\",\"limit\":${LIST_LIMIT},\"offset\":0,\"sortBy\":{\"column\":\"name\",\"order\":\"asc\"}}"
+}
+
+# A listing that hits the limit means entries were silently dropped; a registry
+# built from it would look complete while missing branches. Refuse instead.
+assert_not_truncated() {
+  local count
+  count=$(echo "$1" | jq 'length')
+  if [ "$count" -ge "$LIST_LIMIT" ]; then
+    echo "ERROR: listing for prefix '$2' hit the ${LIST_LIMIT}-entry cap; refusing to build a truncated registry" >&2
+    exit 1
+  fi
+}
+
+has_manifest() {
+  echo "$1" | jq -e 'map(select(.id != null and .name == "manifest.json")) | length > 0' > /dev/null
+}
+
+is_protected() {
+  local name="$1" p
+  for p in "${PROTECTED_CHANNELS[@]}"; do
+    [ "$name" = "$p" ] && return 0
+  done
+  return 1
+}
+
+TOP=$(list "")
+assert_not_truncated "$TOP" ""
+
+REGISTRY='{}'
+while IFS= read -r BRANCH; do
+  [ -n "$BRANCH" ] || continue
+  is_protected "$BRANCH" && continue
+  ENTRIES=$(list "${BRANCH}/")
+  assert_not_truncated "$ENTRIES" "${BRANCH}/"
+  has_manifest "$ENTRIES" || continue
+
+  # Archived commits are subfolders holding their own manifest.json. Sort by
+  # the manifest's created_at so the array keeps the old append order
+  # (oldest -> newest), which is what the flasher's commit dropdown expects.
+  PAIRS='[]'
+  while IFS= read -r SUB; do
+    [ -n "$SUB" ] || continue
+    SUBENTRIES=$(list "${BRANCH}/${SUB}/")
+    if has_manifest "$SUBENTRIES"; then
+      CREATED=$(echo "$SUBENTRIES" | jq -r '.[] | select(.id != null and .name == "manifest.json") | .created_at')
+      PAIRS=$(echo "$PAIRS" | jq --arg c "$SUB" --arg t "$CREATED" '. + [{c:$c, t:$t}]')
+    fi
+  done < <(echo "$ENTRIES" | jq -r '.[] | select(.id == null) | .name')
+
+  COMMITS=$(echo "$PAIRS" | jq 'sort_by(.t) | map(.c)')
+  REGISTRY=$(echo "$REGISTRY" | jq --arg b "$BRANCH" --argjson c "$COMMITS" '. + {($b): $c}')
+done < <(echo "$TOP" | jq -r '.[] | select(.id == null) | .name')
+
+# Never upload anything that is not a JSON object. This inverts the failure
+# mode that caused the 2026-07 outage: worst case is now a red CI job with the
+# previous registry left intact, not a silently poisoned bucket.
+echo "$REGISTRY" | jq -e 'type == "object"' > /dev/null
+echo "$REGISTRY" | jq . > ./registry.json
+[ -s ./registry.json ]
+
+# x-upsert replaces the object in one call. No delete-then-upload window, so a
+# failure anywhere in this script leaves the previous registry untouched and
+# readers never see a 404.
+curl -sf -X POST "${BASE}/object/${BUCKET}/registry.json" \
+  -H "Authorization: Bearer ${STORAGE_KEY}" \
+  -H "apikey: ${STORAGE_KEY}" \
+  -H "Content-Type: application/json" \
+  -H "x-upsert: true" \
+  -H "cache-control: no-cache" \
+  --data-binary @./registry.json > /dev/null
+
+echo "registry.json rebuilt for ${BUCKET}: $(jq -c 'keys' ./registry.json)"

--- a/.github/workflows/master_deploy.yml
+++ b/.github/workflows/master_deploy.yml
@@ -49,21 +49,7 @@ jobs:
         with:
           version: latest
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
-
-      - name: Download registry.json
-        id: download_registry
-        run: |
-          if supabase storage cp "ss:///ossm-firmware/registry.json" ./registry.json --experimental; then
-            echo "registry_exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "Registry.json does not exist. Creating initial registry."
-            echo "{}" > ./registry.json
-            echo "registry_exists=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Determine merged branch and clean up registry
+      - name: Determine merged branch to clean up
         id: cleanup_registry
         run: |
           # Get commits between before and after to find merge commits
@@ -81,10 +67,10 @@ jobs:
                   # URL encode the branch name
                   ENCODED_BRANCH=$(echo "$BRANCH_NAME" | sed 's/\//%2F/g' | sed 's/+/%2B/g' | sed 's/ /%20/g')
                   
-                  # Check if this branch exists in registry
-                  if cat ./registry.json | jq -e "has(\"$ENCODED_BRANCH\")" > /dev/null 2>&1; then
+                  # Check if this branch has firmware in the bucket
+                  if supabase storage ls "ss:///ossm-firmware/$ENCODED_BRANCH/manifest.json" --experimental > /dev/null 2>&1; then
                     MERGED_BRANCH="$ENCODED_BRANCH"
-                    echo "Found merged branch in registry: $MERGED_BRANCH"
+                    echo "Found merged branch in bucket: $MERGED_BRANCH"
                     break
                   fi
                 fi
@@ -92,20 +78,26 @@ jobs:
             done <<< "$MERGE_COMMITS"
           fi
 
-          # If we didn't find it from merge commits, check all branches in registry
+          # If we didn't find it from merge commits, check all branch folders in the bucket
           if [ -z "$MERGED_BRANCH" ]; then
-            echo "Checking all branches in registry for merged branches..."
-            for branch_path in $(cat ./registry.json | jq -r 'keys[]'); do
-              # Skip master branch
-              if [ "$branch_path" = "master" ]; then
+            echo "Checking all bucket folders for merged branches..."
+            for branch_path in $(supabase storage ls "ss:///ossm-firmware/" --experimental | sed 's:/$::'); do
+              # Never touch release channels; they are not git branches
+              case "$branch_path" in
+                master|alpha|production) continue ;;
+              esac
+
+              # Only consider folders that hold flashable firmware
+              if ! supabase storage ls "ss:///ossm-firmware/$branch_path/manifest.json" --experimental > /dev/null 2>&1; then
                 continue
               fi
-              
+
               # Decode branch name (basic URL decode)
               DECODED_BRANCH=$(echo "$branch_path" | sed 's/%2F/\//g' | sed 's/%2B/+/g' | sed 's/%20/ /g')
-              
-              # Check if branch still exists as a remote branch
-              if ! git ls-remote --heads origin "$DECODED_BRANCH" > /dev/null 2>&1; then
+
+              # Check if branch still exists as a remote branch. git ls-remote
+              # exits 0 even when nothing matches, so test its output.
+              if [ -z "$(git ls-remote --heads origin "$DECODED_BRANCH")" ]; then
                 MERGED_BRANCH="$branch_path"
                 echo "Found merged branch (no longer exists): $MERGED_BRANCH"
                 break
@@ -120,41 +112,19 @@ jobs:
             echo "No merged branch found to clean up"
           fi
 
-      - name: Remove merged branch from registry and storage
+      - name: Remove merged branch files from storage
         if: steps.cleanup_registry.outputs.merged_branch != ''
         run: |
           MERGED_BRANCH="${{ steps.cleanup_registry.outputs.merged_branch }}"
-          BUCKET="ossm-firmware"
-
-          # Remove branch from registry
-          REGISTRY=$(cat ./registry.json)
-          REGISTRY=$(echo "$REGISTRY" | jq "del(.[\"$MERGED_BRANCH\"])")
-          echo "$REGISTRY" > ./registry.json
-          echo "Removed $MERGED_BRANCH from registry"
-
-          # Delete all files for this branch from Supabase storage
-          # List all files with the branch prefix
-          RESPONSE=$(curl -s -X POST "https://${SUPABASE_PROJECT_ID}.supabase.co/storage/v1/object/list/${BUCKET}" \
-            -H "apikey: ${SUPABASE_ACCESS_TOKEN}" \
-            -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
-            -H "Content-Type: application/json" \
-            -d "{\"prefix\": \"${MERGED_BRANCH}/\", \"limit\": 1000}")
-
-          # Delete each file
-          echo "$RESPONSE" | jq -r '.[]?.name // empty' | while read -r file; do
-            if [ -n "$file" ]; then
-              echo "Deleting file: $file"
-              curl -s -X DELETE "https://${SUPABASE_PROJECT_ID}.supabase.co/storage/v1/object/${BUCKET}/${file}" \
-                -H "apikey: ${SUPABASE_ACCESS_TOKEN}" \
-                -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" || true
-            fi
-          done
-
+          supabase storage rm "ss:///ossm-firmware/${MERGED_BRANCH}" -r --experimental --yes
           echo "Cleaned up all files for branch: $MERGED_BRANCH"
 
-      - name: Upload updated registry.json
-        if: steps.cleanup_registry.outputs.merged_branch != ''
-        run: |
-          # Delete existing registry.json if it exists, then upload the updated one
-          supabase storage rm "ss:///ossm-firmware/registry.json" --experimental --yes || true
-          supabase storage cp ./registry.json "ss:///ossm-firmware/registry.json" --content-type "application/json" --cache-control "no-cache" --experimental
+  # registry.json is derived state; rebuild it from the bucket on every push to
+  # main (even when cleanup is skipped) so the registry can never stay stale,
+  # corrupt, or missing. `if: always()` keeps this running when
+  # upload_to_supabase is skipped by check_changes.
+  rebuild_registry:
+    needs: [upload_to_supabase]
+    if: always()
+    uses: ./.github/workflows/registry_rebuild.yml
+    secrets: inherit

--- a/.github/workflows/pull_request_action.yml
+++ b/.github/workflows/pull_request_action.yml
@@ -181,76 +181,40 @@ jobs:
         with:
           version: latest
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
-
       - name: Get commit hash
         id: get_commit_hash
         run: |
           COMMIT_HASH=$(git rev-parse --short HEAD)
           echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
 
-      - name: Download registry.json
-        id: download_registry
-        run: |
-          if supabase storage cp "ss:///ossm-firmware/registry.json" ./registry.json --experimental; then
-            echo "registry_exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "Registry.json does not exist. Failing workflow."
-            exit 1
-          fi
-
-      - name: Determine old commit and update registry
+      # The registry is no longer read or edited here; it is rebuilt from the
+      # bucket after the firmware upload (see rebuild_registry.sh). This step
+      # only names the archive folder for the firmware currently at the branch
+      # head, derived from git history.
+      - name: Determine old commit
         id: update_registry
         run: |
           BRANCH_PATH="${{ steps.encode_branch.outputs.encoded_branch }}"
           CURRENT_COMMIT="${{ steps.get_commit_hash.outputs.commit_hash }}"
 
-          # Read registry.json
-          REGISTRY=$(cat ./registry.json)
-
-          # Check if branch exists in registry, create empty array if not
-          if ! echo "$REGISTRY" | jq -e "has(\"$BRANCH_PATH\")" > /dev/null; then
-            echo "Branch $BRANCH_PATH not in registry, creating entry"
-            REGISTRY=$(echo "$REGISTRY" | jq ". + {\"$BRANCH_PATH\": []}")
-          fi
-
-          # Check if firmware exists at branch path
           OLD_COMMIT=""
           if supabase storage ls "ss:///ossm-firmware/$BRANCH_PATH/firmware.bin" --experimental > /dev/null 2>&1; then
-            # Firmware exists, need to determine old commit
-            # First, check if there's a previous commit in the registry for this branch
-            BRANCH_COMMITS=$(echo "$REGISTRY" | jq -r ".[\"$BRANCH_PATH\"] // []")
-            COMMIT_COUNT=$(echo "$BRANCH_COMMITS" | jq "length")
-            
-            if [ "$COMMIT_COUNT" -gt 0 ]; then
-              # Use the last commit in the array (most recent)
-              OLD_COMMIT=$(echo "$BRANCH_COMMITS" | jq -r ".[-1]")
-              echo "Found old commit from registry: $OLD_COMMIT"
-            else
-              # No commits in registry, try to find the commit from git history
-              # Find the last commit that modified Software files before current commit
-              OLD_COMMIT=$(git log --format="%h" -1 --skip=1 -- Software/ 2>/dev/null || echo "")
-              if [ -z "$OLD_COMMIT" ]; then
-                # Fallback: use parent commit
-                OLD_COMMIT=$(git rev-parse --short HEAD^ 2>/dev/null || echo "")
-              fi
-              if [ -n "$OLD_COMMIT" ]; then
-                echo "Determined old commit from git: $OLD_COMMIT"
-              else
-                echo "Warning: Could not determine old commit, using current commit"
-                OLD_COMMIT="$CURRENT_COMMIT"
-              fi
+            # Find the last commit that modified Software files before current commit
+            OLD_COMMIT=$(git log --format="%h" -1 --skip=1 -- Software/ 2>/dev/null || echo "")
+            if [ -z "$OLD_COMMIT" ]; then
+              # Fallback: use parent commit
+              OLD_COMMIT=$(git rev-parse --short HEAD^ 2>/dev/null || echo "")
             fi
-            
-            # Add old commit to registry if not already present
-            REGISTRY=$(echo "$REGISTRY" | jq ".[\"$BRANCH_PATH\"] |= (. + [\"$OLD_COMMIT\"] | unique)")
+            if [ -n "$OLD_COMMIT" ]; then
+              echo "Determined old commit from git: $OLD_COMMIT"
+            else
+              echo "Warning: Could not determine old commit, using current commit"
+              OLD_COMMIT="$CURRENT_COMMIT"
+            fi
           else
             echo "No existing firmware found at $BRANCH_PATH, this is first upload"
           fi
 
-          # Save updated registry
-          echo "$REGISTRY" > ./registry.json
           echo "old_commit=$OLD_COMMIT" >> $GITHUB_OUTPUT
 
       - name: Move existing firmware out of the way
@@ -286,11 +250,11 @@ jobs:
           # Upload the manifest file to Supabase Storage
           supabase storage cp ./manifest.json "ss:///ossm-firmware/$BRANCH_PATH/manifest.json" --content-type "application/json" --cache-control "no-cache" --experimental
 
-      - name: Upload updated registry.json
-        run: |
-          # Delete existing registry.json if it exists, then upload the updated one
-          supabase storage rm "ss:///ossm-firmware/registry.json" --experimental --yes || true
-          supabase storage cp ./registry.json "ss:///ossm-firmware/registry.json" --content-type "application/json" --cache-control "no-cache" --experimental
+      # Runs before the GitHub Deployment is created so the deployment's
+      # ?branch= flasher link resolves against a registry that already lists
+      # this branch.
+      - name: Rebuild registry from bucket contents
+        run: bash .github/scripts/rebuild_registry.sh
 
       - name: Create GitHub Deployment
         id: create_deployment

--- a/.github/workflows/registry_rebuild.yml
+++ b/.github/workflows/registry_rebuild.yml
@@ -1,0 +1,30 @@
+name: Rebuild Firmware Registry
+
+# registry.json is derived state: rebuilt from the bucket's actual contents,
+# never edited in place. See .github/scripts/rebuild_registry.sh.
+#
+# Invoked:
+#   - by Master Branch Cleanup on every push to main (workflow_call)
+#   - at the end of every PR firmware upload (as an in-job step, not this file)
+#   - manually via workflow_dispatch for on-demand healing/verification
+
+on:
+  workflow_dispatch: {}
+  workflow_call: {}
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    # Queue concurrent rebuilds instead of interleaving uploads. Rebuilds are
+    # idempotent (full state from ground truth), so the last one wins safely.
+    concurrency:
+      group: ossm-firmware-registry
+      cancel-in-progress: false
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Rebuild registry from bucket contents
+        run: bash .github/scripts/rebuild_registry.sh


### PR DESCRIPTION
## RAD-2144 — recovery half of the web-flasher registry outage (2 of 3)

Fixes the OSSM web flasher (https://docs.researchanddesire.com/ossm/tools/web-flasher), which currently shows a branch-load error because `ossm-firmware/registry.json` in prod storage is an empty/corrupt file. **Merging this PR is itself the repair**: the new `rebuild_registry` job runs on the push to main and regenerates the registry from the bucket. No manual bucket operations at any point.

### Problem
- The prod registry was overwritten out-of-band with an empty file (prevention fix: researchanddesire/rad-app#1582 — merge that first).
- This repo's CI then perpetuated the corruption: `REGISTRY=$(echo "$REGISTRY" | jq ...)` emits nothing on empty input with exit 0, so every PR build re-uploaded a 1-byte newline with a green check (runs 29267216304, 29267525567).
- No CI path could recreate the object: the PR workflow hard-failed when it was missing; master_deploy's `{}` bootstrap was gated behind a `merged_branch` condition an empty registry can never satisfy.

### Approach
`registry.json` becomes **derived state**, rebuilt from the bucket listing (ground truth) and uploaded whole. Nothing ever reads the previous copy, so corrupt/empty/missing registries cannot propagate. Details and per-change reasoning are in the commit message.

Also fixes latent cleanup bugs found during the rewrite: the curl-based branch deletion never worked (platform token used against the storage API, prefix-relative names, one-level listing), and the `git ls-remote` fallback check never fired (exit 0 on no match). Since deletion now works, `master`/`alpha`/`production` are explicitly protected.

### Verification done
- All workflow YAML parses; script passes bash -n.
- Full dry run of the script against a mocked storage API: release channels and non-firmware folders excluded, commits ordered oldest→newest, newline-only corruption rejected before upload.
- `supabase storage rm -r` usage matches the CLI's documented example.

### Verification after merge
1. Watch the `rebuild_registry` job log for `registry.json rebuilt: [...]`.
2. `curl -s https://acjajruwevyyatztbkdf.supabase.co/storage/v1/object/public/ossm-firmware/registry.json | jq .` → valid object.
3. Load the flasher page: no error banner; Production flash button unaffected.
4. Next real firmware PR exercises the add path; its merge exercises cleanup.

Siblings: researchanddesire/rad-app#1582 (prevention), radr-wireless-remote (same treatment for `radr-firmware`).
