### PR TITLE
RAD-2144: discover nested branch folders when rebuilding the firmware registry

### DIFF
--- a/.github/scripts/rebuild_registry.sh
+++ b/.github/scripts/rebuild_registry.sh
@@ -4,6 +4,22 @@
 # registry.json, so a corrupt, empty, or missing one cannot propagate. Safe to
 # run at any time; the last run to finish always converges on ground truth.
 #
+# Bucket layout: branch names containing slashes are stored as real nested
+# paths (branch kareem/foo lives under kareem/foo/, NOT under a folder
+# literally named kareem%2Ffoo — the CLI and the storage API percent-decode
+# object paths). Registry keys, by contrast, are URL-encoded (kareem%2Ffoo)
+# because the web flasher builds manifest URLs from them and the encoding
+# decodes back to the nested path when fetched. Discovery below therefore
+# recurses into folders that hold no manifest.json (pure namespaces) and
+# re-encodes the joined path for the registry key.
+#
+# Usage:
+#   rebuild_registry.sh                  rebuild and upload registry.json
+#   rebuild_registry.sh --list-branches  print discovered branch keys, one per
+#                                        line, and write nothing (used by the
+#                                        cleanup workflow to find stale
+#                                        branches)
+#
 # Required env:
 #   SUPABASE_ACCESS_TOKEN  - platform token (sbp_...) or project service key
 #   SUPABASE_PROJECT_ID    - project ref
@@ -15,6 +31,13 @@ BUCKET="ossm-firmware"
 PROTECTED_CHANNELS=("master" "alpha" "production")
 BASE="https://${SUPABASE_PROJECT_ID}.supabase.co/storage/v1"
 LIST_LIMIT=1000
+# Namespace nesting bound: a branch named a/b/c/d is four segments deep.
+MAX_DEPTH=4
+
+MODE="rebuild"
+if [ "${1:-}" = "--list-branches" ]; then
+  MODE="list"
+fi
 
 # The storage REST API needs a project JWT. CI stores a platform access token
 # (sbp_...), so exchange it for the service_role key the same way the CLI does.
@@ -26,14 +49,14 @@ else
   STORAGE_KEY="${SUPABASE_ACCESS_TOKEN}"
 fi
 
-# One-level listing. Prefix travels in the JSON body, so URL-encoded branch
-# names (kareem%2Fmy-branch) need no extra escaping. Folders have "id": null.
+# One-level listing. The prefix travels in the JSON body, so nested paths need
+# no URL escaping. Folders come back with "id": null; files with a uuid id.
 list() {
   curl -sf -X POST "${BASE}/object/list/${BUCKET}" \
     -H "Authorization: Bearer ${STORAGE_KEY}" \
     -H "apikey: ${STORAGE_KEY}" \
     -H "Content-Type: application/json" \
-    -d "{\"prefix\":\"$1\",\"limit\":${LIST_LIMIT},\"offset\":0,\"sortBy\":{\"column\":\"name\",\"order\":\"asc\"}}"
+    -d "$(jq -nc --arg p "$1" --argjson l "$LIST_LIMIT" '{prefix: $p, limit: $l, offset: 0, sortBy: {column: "name", order: "asc"}}')"
 }
 
 # A listing that hits the limit means entries were silently dropped; a registry
@@ -59,33 +82,77 @@ is_protected() {
   return 1
 }
 
+# Mirror of the workflows' URL encoder (encode_branch step), which encodes
+# slash, plus, and space. Slashes are re-added by the joiner in discover(), so
+# per segment only plus and space need escaping.
+encode_segment() {
+  echo "$1" | sed 's/+/%2B/g' | sed 's/ /%20/g'
+}
+
+REGISTRY='{}'
+BRANCH_KEYS=""
+
+# Record the branch root found at bucket path $1 (e.g. kareem/foo) under
+# registry key $2 (e.g. kareem%2Ffoo). Its commits are subfolders that look
+# like short git hashes and hold their own manifest.json, sorted by that
+# manifest's created_at so the array keeps the old append order.
+register_branch() {
+  local path="$1" key="$2" entries="$3"
+  local pairs sub subentries created commits
+  pairs='[]'
+  while IFS= read -r sub; do
+    [ -n "$sub" ] || continue
+    echo "$sub" | grep -qE '^[0-9a-f]{7,12}$' || continue
+    subentries=$(list "${path}/${sub}/")
+    if has_manifest "$subentries"; then
+      created=$(echo "$subentries" | jq -r '.[] | select(.id != null and .name == "manifest.json") | .created_at')
+      pairs=$(echo "$pairs" | jq --arg c "$sub" --arg t "$created" '. + [{c:$c, t:$t}]')
+    fi
+  done < <(echo "$entries" | jq -r '.[] | select(.id == null) | .name')
+
+  commits=$(echo "$pairs" | jq 'sort_by(.t) | map(.c)')
+  REGISTRY=$(echo "$REGISTRY" | jq --arg b "$key" --argjson c "$commits" '. + {($b): $c}')
+  BRANCH_KEYS="${BRANCH_KEYS}${key}"$'\n'
+}
+
+# Depth-first discovery. A folder holding a manifest.json is a branch root; a
+# folder without one is a namespace segment of a slash-named branch and is
+# recursed into.
+discover() {
+  local path="$1" key="$2" depth="$3"
+  local entries sub
+  entries=$(list "${path}/")
+  assert_not_truncated "$entries" "${path}/"
+
+  if has_manifest "$entries"; then
+    register_branch "$path" "$key" "$entries"
+    return 0
+  fi
+
+  if [ "$depth" -ge "$MAX_DEPTH" ]; then
+    echo "WARN: no manifest within depth ${MAX_DEPTH} under '${path}/'; skipping" >&2
+    return 0
+  fi
+
+  while IFS= read -r sub; do
+    [ -n "$sub" ] || continue
+    discover "${path}/${sub}" "${key}%2F$(encode_segment "$sub")" $((depth + 1))
+  done < <(echo "$entries" | jq -r '.[] | select(.id == null) | .name')
+}
+
 TOP=$(list "")
 assert_not_truncated "$TOP" ""
 
-REGISTRY='{}'
-while IFS= read -r BRANCH; do
-  [ -n "$BRANCH" ] || continue
-  is_protected "$BRANCH" && continue
-  ENTRIES=$(list "${BRANCH}/")
-  assert_not_truncated "$ENTRIES" "${BRANCH}/"
-  has_manifest "$ENTRIES" || continue
-
-  # Archived commits are subfolders holding their own manifest.json. Sort by
-  # the manifest's created_at so the array keeps the old append order
-  # (oldest -> newest), which is what the flasher's commit dropdown expects.
-  PAIRS='[]'
-  while IFS= read -r SUB; do
-    [ -n "$SUB" ] || continue
-    SUBENTRIES=$(list "${BRANCH}/${SUB}/")
-    if has_manifest "$SUBENTRIES"; then
-      CREATED=$(echo "$SUBENTRIES" | jq -r '.[] | select(.id != null and .name == "manifest.json") | .created_at')
-      PAIRS=$(echo "$PAIRS" | jq --arg c "$SUB" --arg t "$CREATED" '. + [{c:$c, t:$t}]')
-    fi
-  done < <(echo "$ENTRIES" | jq -r '.[] | select(.id == null) | .name')
-
-  COMMITS=$(echo "$PAIRS" | jq 'sort_by(.t) | map(.c)')
-  REGISTRY=$(echo "$REGISTRY" | jq --arg b "$BRANCH" --argjson c "$COMMITS" '. + {($b): $c}')
+while IFS= read -r FOLDER; do
+  [ -n "$FOLDER" ] || continue
+  is_protected "$FOLDER" && continue
+  discover "$FOLDER" "$(encode_segment "$FOLDER")" 1
 done < <(echo "$TOP" | jq -r '.[] | select(.id == null) | .name')
+
+if [ "$MODE" = "list" ]; then
+  printf '%s' "$BRANCH_KEYS"
+  exit 0
+fi
 
 # Never upload anything that is not a JSON object. This inverts the failure
 # mode that caused the 2026-07 outage: worst case is now a red CI job with the

--- a/.github/workflows/master_deploy.yml
+++ b/.github/workflows/master_deploy.yml
@@ -78,20 +78,14 @@ jobs:
             done <<< "$MERGE_COMMITS"
           fi
 
-          # If we didn't find it from merge commits, check all branch folders in the bucket
+          # If we didn't find it from merge commits (squash merges never match
+          # that path), scan the bucket for branch folders whose git branch no
+          # longer exists. Discovery is delegated to the rebuild script so
+          # nested folders for slash-named branches (kareem/foo) are found;
+          # it emits URL-encoded branch keys and never emits release channels.
           if [ -z "$MERGED_BRANCH" ]; then
-            echo "Checking all bucket folders for merged branches..."
-            for branch_path in $(supabase storage ls "ss:///ossm-firmware/" --experimental | sed 's:/$::'); do
-              # Never touch release channels; they are not git branches
-              case "$branch_path" in
-                master|alpha|production) continue ;;
-              esac
-
-              # Only consider folders that hold flashable firmware
-              if ! supabase storage ls "ss:///ossm-firmware/$branch_path/manifest.json" --experimental > /dev/null 2>&1; then
-                continue
-              fi
-
+            echo "Checking all bucket branch folders for merged branches..."
+            for branch_path in $(bash .github/scripts/rebuild_registry.sh --list-branches); do
               # Decode branch name (basic URL decode)
               DECODED_BRANCH=$(echo "$branch_path" | sed 's/%2F/\//g' | sed 's/%2B/+/g' | sed 's/%20/ /g')
 


### PR DESCRIPTION
## RAD-2144 follow-up: nested branch folders were invisible to the registry rebuild

Fixes a gap in #287 discovered right after merge: branch names containing slashes (`kareem/...`, `hotfix/...`) are stored as **nested paths** in the bucket (the storage API percent-decodes object keys), but the rebuild script only scanned one level deep. Result: slash-named branches were silently omitted from `registry.json` — a regression against pre-outage dropdown behavior (verified in prod: `kareem/rad-2140.../manifest.json` answers 200 at the nested path while the rebuilt registry listed only `Increase-speed`).

### Changes
- **`rebuild_registry.sh`**: bounded depth-first discovery (folder with `manifest.json` = branch root; folder without = namespace segment, recursed). Registry keys re-encoded per segment (`%2F` joins, `+`/space escapes) to keep the flasher contract byte-identical. Commit subfolders must now be hash-shaped (`^[0-9a-f]{7,12}$`) as well as manifest-bearing. New `--list-branches` mode prints discovered keys without writing, so cleanup and rebuild share one discovery implementation.
- **`master_deploy.yml`**: the fallback merged-branch scan iterates `--list-branches` output instead of a one-level `storage ls`. This matters here specifically: this repo squash-merges, so the merge-commit-message detection path never matches, making the fallback the *only* cleanup that ever fires. With this change the stale merged `kareem/rad-2140...` folder gets auto-deleted on a subsequent push to main.

### Verification
- Dry run against a mock reproducing the real nested layout: flat + nested branches discovered, keys encoded correctly, non-hash subfolders ignored, `--list-branches` output matches; `bash -n`/YAML clean.
- After merge: rebuild log should show both `Increase-speed` and `kareem%2Frad-2140-...` as registry keys, and the dev dropdown on the docs flasher should list `kareem/rad-2140-...` (stale but real, until cleanup collects it).

Twin PR in radr-wireless-remote (same fix, `radr-firmware`).
