### PR TITLE
Add immutable track-aware firmware publishing

### DIFF
--- a/.github/scripts/download_verified_release.py
+++ b/.github/scripts/download_verified_release.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Download a validation-gated immutable release for an explicit legacy alias."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+CONTROL_PLANE = "https://dashboard.researchanddesire.com"
+REQUIRED_GATES = {"build", "unit", "integration", "artifact", "hardware"}
+
+
+def fetch(url: str, token: str | None = None) -> bytes:
+    headers = {"User-Agent": "rad-firmware-alias/1"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            return response.read()
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode(errors="replace")
+        raise RuntimeError(f"download returned HTTP {error.code}: {detail}") from error
+
+
+def download_release(release_id: str, track: str, device: str, output: Path) -> str:
+    token = os.environ.get("FIRMWARE_PUBLISH_TOKEN", "").strip()
+    if not token:
+        raise RuntimeError("FIRMWARE_PUBLISH_TOKEN is required")
+    base = os.environ.get("FIRMWARE_CONTROL_PLANE_BASE_URL", CONTROL_PLANE).rstrip("/")
+    status = json.loads(fetch(f"{base}/api/internal/firmware/v1/releases/{release_id}?track={track}", token))
+    if status.get("track") != track or status.get("deviceType") != device:
+        raise RuntimeError("release track or device family does not match")
+    allowed = {"active"} if track == "staging" else {"ready", "active"}
+    if status.get("lifecycle") not in allowed:
+        raise RuntimeError("release has not passed the required lifecycle gate")
+    build_sha = status.get("buildSha")
+    passed = {
+        result["layer"]
+        for result in status.get("validations", [])
+        if result.get("status") == "success" and result.get("repository_sha") == build_sha
+    }
+    if not REQUIRED_GATES.issubset(passed):
+        raise RuntimeError("release is missing a successful persisted validation gate")
+    manifest_url = status["manifestUrl"]
+    manifest_bytes = fetch(manifest_url)
+    manifest = json.loads(manifest_bytes)
+    if manifest.get("track") != track or manifest.get("deviceType") != device or manifest.get("buildSha") != build_sha:
+        raise RuntimeError("manifest identity does not match the release")
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "manifest.json").write_bytes(manifest_bytes)
+    object_base = manifest_url.rsplit("/", 1)[0]
+    for artifact in manifest.get("artifacts", []):
+        filename = artifact.get("filename", "")
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", filename):
+            raise RuntimeError("manifest contains an unsafe filename")
+        content = fetch(f"{object_base}/{filename}")
+        if len(content) != artifact.get("sizeBytes"):
+            raise RuntimeError(f"size mismatch for {filename}")
+        if hashlib.sha256(content).hexdigest() != artifact.get("sha256"):
+            raise RuntimeError(f"SHA-256 mismatch for {filename}")
+        (output / filename).write_bytes(content)
+    (output / "version.json").write_text(json.dumps({"version": status["version"], "buildSha": build_sha, "releaseId": release_id}, indent=2) + "\n")
+    return status["version"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--release-id", required=True)
+    parser.add_argument("--track", required=True, choices=("main", "staging"))
+    parser.add_argument("--device", required=True, choices=("dtt", "lkbx", "ossm", "radr"))
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    version = download_release(args.release_id, args.track, args.device, args.output)
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as handle:
+            handle.write(f"version={version}\n")
+    print(version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/publish_immutable_firmware.py
+++ b/.github/scripts/publish_immutable_firmware.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Publish a verified immutable firmware candidate through the RAD control plane."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+CONTROL_PLANE = "https://dashboard.researchanddesire.com"
+PROJECT_REFS = {
+    "main": "acjajruwevyyatztbkdf",
+    "staging": "meuaxbjzqrszxdvmacug",
+}
+VALID_ROLES = {"application", "filesystem", "bootloader", "partitions"}
+
+
+@dataclass(frozen=True)
+class Artifact:
+    role: str
+    path: Path
+    install_order: int
+    installable: bool
+
+    @property
+    def filename(self) -> str:
+        return self.path.name
+
+    @property
+    def content(self) -> bytes:
+        return self.path.read_bytes()
+
+    @property
+    def sha256(self) -> str:
+        return hashlib.sha256(self.content).hexdigest()
+
+    @property
+    def size_bytes(self) -> int:
+        return self.path.stat().st_size
+
+
+def parse_artifact(value: str) -> Artifact:
+    try:
+        role, path, order, installable = value.split(":", 3)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            "artifact must be ROLE:PATH:ORDER:INSTALLABLE"
+        ) from error
+    if role not in VALID_ROLES:
+        raise argparse.ArgumentTypeError(f"unsupported artifact role: {role}")
+    artifact = Artifact(role, Path(path), int(order), installable.lower() == "true")
+    if not artifact.path.is_file() or artifact.size_bytes == 0:
+        raise argparse.ArgumentTypeError(f"artifact is missing or empty: {artifact.path}")
+    return artifact
+
+
+def read_version(path: Path) -> str:
+    match = re.search(r'^#define VERSION "(\d+\.\d+\.\d+)"$', path.read_text(), re.M)
+    if not match:
+        raise ValueError(f"unable to read semantic version from {path}")
+    return match.group(1)
+
+
+def json_bytes(value: Any) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def request_json(url: str, token: str, payload: dict[str, Any]) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        data=json_bytes(payload),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "rad-firmware-publisher/1",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode(errors="replace")
+        raise RuntimeError(f"control plane returned HTTP {error.code}: {detail}") from error
+
+
+def upload_file(url: str, content: bytes, content_type: str) -> None:
+    request = urllib.request.Request(
+        url,
+        data=content,
+        headers={"Content-Type": content_type, "x-upsert": "false"},
+        method="PUT",
+    )
+    with urllib.request.urlopen(request, timeout=120) as response:
+        if response.status not in (200, 201):
+            raise RuntimeError(f"signed upload returned HTTP {response.status}")
+
+
+def verify_public_object(url: str, sha256: str, size_bytes: int) -> None:
+    last_error: Exception | None = None
+    for attempt in range(5):
+        try:
+            with urllib.request.urlopen(url, timeout=120) as response:
+                content = response.read()
+            if len(content) != size_bytes:
+                raise RuntimeError(f"size mismatch for {url}")
+            if hashlib.sha256(content).hexdigest() != sha256:
+                raise RuntimeError(f"SHA-256 mismatch for {url}")
+            return
+        except (OSError, RuntimeError, urllib.error.URLError) as error:
+            last_error = error
+            time.sleep(2**attempt)
+    raise RuntimeError(f"public object verification failed: {last_error}")
+
+
+def validation_payload(release_id: str, layer: str, status: str, args: argparse.Namespace) -> dict[str, Any]:
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    workflow_url = f"https://github.com/{repository}/actions/runs/{run_id}"
+    payload: dict[str, Any] = {
+        "releaseId": release_id,
+        "layer": layer,
+        "deviceType": args.device_type,
+        "repositorySha": args.build_sha,
+        "status": status,
+        "runner": os.environ.get("RUNNER_NAME", "github-actions"),
+    }
+    if repository and run_id:
+        payload["workflowRunUrl"] = workflow_url
+    return payload
+
+
+def publish(args: argparse.Namespace) -> str:
+    token = os.environ.get("FIRMWARE_PUBLISH_TOKEN", "").strip()
+    if not token:
+        raise RuntimeError("FIRMWARE_PUBLISH_TOKEN is required")
+    if args.track not in PROJECT_REFS:
+        raise RuntimeError("track must be main or staging")
+    if not re.fullmatch(r"[0-9a-fA-F]{7,64}", args.build_sha):
+        raise RuntimeError("build SHA must contain 7 to 64 hexadecimal characters")
+    version = read_version(args.version_file)
+    installable = sorted(
+        (artifact for artifact in args.artifact if artifact.installable),
+        key=lambda artifact: artifact.install_order,
+    )
+    if not any(artifact.role == "application" for artifact in installable):
+        raise RuntimeError("an installable application artifact is required")
+    if len({artifact.filename for artifact in args.artifact}) != len(args.artifact):
+        raise RuntimeError("artifact filenames must be unique")
+    if len({artifact.install_order for artifact in args.artifact}) != len(args.artifact):
+        raise RuntimeError("artifact install orders must be unique")
+
+    metadata = [
+        {
+            "role": artifact.role,
+            "filename": artifact.filename,
+            "sha256": artifact.sha256,
+            "sizeBytes": artifact.size_bytes,
+            "installOrder": artifact.install_order,
+            "installable": artifact.installable,
+        }
+        for artifact in sorted(args.artifact, key=lambda item: item.install_order)
+    ]
+    generated_dir = Path(os.environ.get("RUNNER_TEMP", ".pio")) / "firmware-release"
+    generated_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = generated_dir / "manifest.json"
+    release_path = generated_dir / "release.json"
+    manifest_path.write_bytes(
+        json_bytes(
+            {
+                "protocolVersion": 1,
+                "deviceType": args.device_type,
+                "track": args.track,
+                "version": version,
+                "buildSha": args.build_sha,
+                "artifacts": metadata,
+            }
+        )
+    )
+    release_path.write_bytes(
+        json_bytes(
+            {
+                "protocolVersion": 1,
+                "deviceType": args.device_type,
+                "track": args.track,
+                "version": version,
+                "buildSha": args.build_sha,
+                "kind": args.kind,
+                "manifest": "manifest.json",
+            }
+        )
+    )
+    generated = [
+        Artifact("manifest", manifest_path, max(item.install_order for item in args.artifact) + 1, False),
+        Artifact("release", release_path, max(item.install_order for item in args.artifact) + 2, False),
+    ]
+    all_artifacts = [*args.artifact, *generated]
+    upload_request = {
+        "track": args.track,
+        "deviceType": args.device_type,
+        "version": version,
+        "buildSha": args.build_sha,
+        "storageProjectRef": PROJECT_REFS[args.track],
+        "bucketId": f"{args.device_type}-firmware",
+        "artifacts": [
+            {
+                "role": artifact.role,
+                "filename": artifact.filename,
+                "sha256": artifact.sha256,
+                "sizeBytes": artifact.size_bytes,
+                "installOrder": artifact.install_order,
+                "contentType": "application/json" if artifact.path.suffix == ".json" else "application/octet-stream",
+            }
+            for artifact in all_artifacts
+        ],
+    }
+    base_url = os.environ.get("FIRMWARE_CONTROL_PLANE_BASE_URL", CONTROL_PLANE).rstrip("/")
+    upload_base_url = os.environ.get(
+        "FIRMWARE_UPLOAD_BASE_URL",
+        "https://staging.researchanddesire.com" if args.track == "staging" else base_url,
+    ).rstrip("/")
+    signed = request_json(f"{upload_base_url}/api/internal/firmware/v1/uploads", token, upload_request)
+    by_name = {artifact.filename: artifact for artifact in all_artifacts}
+    for upload in signed["uploads"]:
+        artifact = by_name[upload["filename"]]
+        content_type = "application/json" if artifact.path.suffix == ".json" else "application/octet-stream"
+        upload_file(upload["signedUrl"], artifact.content, content_type)
+        verify_public_object(upload["publicUrl"], artifact.sha256, artifact.size_bytes)
+
+    uploads_by_name = {upload["filename"]: upload for upload in signed["uploads"]}
+    release_request = {
+        "track": args.track,
+        "deviceType": args.device_type,
+        "version": version,
+        "buildSha": args.build_sha,
+        "kind": args.kind,
+        "storageProjectRef": PROJECT_REFS[args.track],
+        "bucketId": f"{args.device_type}-firmware",
+        "objectPrefix": signed["objectPrefix"],
+        "artifacts": [
+            {
+                "role": artifact.role,
+                "objectPath": uploads_by_name[artifact.filename]["objectPath"],
+                "publicUrl": uploads_by_name[artifact.filename]["publicUrl"],
+                "sha256": artifact.sha256,
+                "sizeBytes": artifact.size_bytes,
+                "required": True,
+                "installOrder": artifact.install_order,
+            }
+            for artifact in installable
+        ],
+    }
+    published = request_json(f"{base_url}/api/internal/firmware/v1/releases", token, release_request)
+    release_id = published["releaseId"]
+    try:
+        for layer in ("build", "unit", "integration"):
+            request_json(
+                f"{base_url}/api/internal/firmware/v1/validations",
+                token,
+                validation_payload(release_id, layer, "success", args),
+            )
+    except Exception:
+        request_json(
+            f"{base_url}/api/internal/firmware/v1/validations",
+            token,
+            validation_payload(release_id, "integration", "failed", args),
+        )
+        raise
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as handle:
+            handle.write(f"release_id={release_id}\n")
+    return release_id
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device-type", required=True, choices=("dtt", "lkbx", "ossm", "radr"))
+    parser.add_argument("--track", required=True, choices=("main", "staging"))
+    parser.add_argument("--build-sha", required=True)
+    parser.add_argument("--version-file", required=True, type=Path)
+    parser.add_argument("--kind", default="firmware", choices=("firmware", "migration"))
+    parser.add_argument("--artifact", action="append", required=True, type=parse_artifact)
+    args = parser.parse_args()
+    try:
+        release_id = publish(args)
+        print(f"Published validating release {release_id}")
+        return 0
+    except Exception as error:
+        print(f"Publication failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/release_workflow.py
+++ b/.github/scripts/release_workflow.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Small, unit-tested helpers shared by release workflows."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from pathlib import Path
+
+PROJECT_REFS = {
+    "main": "acjajruwevyyatztbkdf",
+    "staging": "meuaxbjzqrszxdvmacug",
+}
+
+
+def branch_configuration(branch: str) -> dict[str, str]:
+    if branch == "main":
+        return {
+            "TRACK": "main",
+            "PIO_ENV": "production",
+            "STORAGE_PROJECT_REF": PROJECT_REFS["main"],
+        }
+    if branch == "staging":
+        return {
+            "TRACK": "staging",
+            "PIO_ENV": "staging",
+            "STORAGE_PROJECT_REF": PROJECT_REFS["staging"],
+        }
+    raise ValueError("firmware publication is restricted to main or staging")
+
+
+def tag_action(existing_sha: str | None, candidate_sha: str) -> str:
+    candidate = candidate_sha.strip().lower()
+    existing = (existing_sha or "").strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{7,64}", candidate):
+        raise ValueError("candidate SHA is invalid")
+    if not existing:
+        return "create"
+    if not re.fullmatch(r"[0-9a-f]{7,64}", existing):
+        raise ValueError("existing tag SHA is invalid")
+    if existing != candidate:
+        raise ValueError("tag already targets a different commit")
+    return "exists"
+
+
+def append_github_env(values: dict[str, str]) -> None:
+    path = os.environ.get("GITHUB_ENV")
+    if not path:
+        raise RuntimeError("GITHUB_ENV is required")
+    with Path(path).open("a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            handle.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+    configure = commands.add_parser("configure")
+    configure.add_argument("--branch", required=True)
+    tag = commands.add_parser("tag-action")
+    tag.add_argument("--existing-sha", default="")
+    tag.add_argument("--candidate-sha", required=True)
+    args = parser.parse_args()
+    if args.command == "configure":
+        values = branch_configuration(args.branch)
+        append_github_env(values)
+        return 0
+    print(tag_action(args.existing_sha, args.candidate_sha))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_publish_immutable_firmware.py
+++ b/.github/scripts/test_publish_immutable_firmware.py
@@ -1,0 +1,31 @@
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+
+from publish_immutable_firmware import parse_artifact, read_version
+
+
+class PublisherTests(unittest.TestCase):
+    def test_reads_numeric_semantic_version(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "Version.h"
+            path.write_text('#define VERSION "1.2.3"\n')
+            self.assertEqual(read_version(path), "1.2.3")
+
+    def test_rejects_missing_artifact(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            parse_artifact("application:missing.bin:1:true")
+
+    def test_parses_installable_artifact(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "firmware.bin"
+            path.write_bytes(b"firmware")
+            artifact = parse_artifact(f"application:{path}:2:true")
+            self.assertTrue(artifact.installable)
+            self.assertEqual(artifact.install_order, 2)
+            self.assertEqual(artifact.sha256, "c3bf47ea1f4a4a605470313cacb3a44f4a461f68c6faeab07e737610cb5ac835")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_release_workflow.py
+++ b/.github/scripts/test_release_workflow.py
@@ -1,0 +1,38 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from release_workflow import branch_configuration, main, tag_action
+
+
+class ReleaseWorkflowTests(unittest.TestCase):
+    def test_branch_configuration_maps_tracks_and_projects(self):
+        self.assertEqual(branch_configuration("main")["PIO_ENV"], "production")
+        self.assertEqual(branch_configuration("staging")["PIO_ENV"], "staging")
+        self.assertNotEqual(
+            branch_configuration("main")["STORAGE_PROJECT_REF"],
+            branch_configuration("staging")["STORAGE_PROJECT_REF"],
+        )
+        with self.assertRaises(ValueError):
+            branch_configuration("feature")
+
+    def test_tag_action_is_idempotent_and_fails_on_collision(self):
+        sha = "a" * 40
+        self.assertEqual(tag_action("", sha), "create")
+        self.assertEqual(tag_action(sha, sha), "exists")
+        with self.assertRaisesRegex(ValueError, "different commit"):
+            tag_action("b" * 40, sha)
+
+    def test_configure_writes_github_environment(self):
+        with tempfile.TemporaryDirectory() as directory:
+            env_file = Path(directory) / "env"
+            with patch.dict("os.environ", {"GITHUB_ENV": str(env_file)}), patch(
+                "sys.argv", ["release_workflow.py", "configure", "--branch", "staging"]
+            ):
+                self.assertEqual(main(), 0)
+            self.assertIn("TRACK=staging", env_file.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/finalize_release.yml
+++ b/.github/workflows/finalize_release.yml
@@ -1,0 +1,75 @@
+name: Finalize validated production release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_id:
+        description: Validated control-plane release UUID
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    environment: firmware-production
+    env:
+      GH_TOKEN: ${{ github.token }}
+      FIRMWARE_PUBLISH_TOKEN: ${{ secrets.FIRMWARE_PUBLISH_TOKEN }}
+    steps:
+      - name: Checkout exact main candidate
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Verify persisted release gates
+        id: release
+        run: |
+          curl --fail --silent --show-error \\
+            --header "Authorization: Bearer $FIRMWARE_PUBLISH_TOKEN" \\
+            "https://dashboard.researchanddesire.com/api/internal/firmware/v1/releases/${{ inputs.release_id }}?track=main" \\
+            --output release.json
+          jq -e --arg sha "$GITHUB_SHA" --arg device "ossm" '
+            . as $release |
+            $release.track == "main" and
+            $release.deviceType == $device and
+            $release.buildSha == $sha and
+            $release.lifecycle == "ready" and
+            $release.paused == true and
+            $release.rolloutPercentage == 0 and
+            (["build", "unit", "integration", "artifact", "hardware"] | all(. as $layer |
+              any($release.validations[]; .layer == $layer and .status == "success" and .repository_sha == $sha)
+            ))
+          ' release.json
+          echo "version=$(jq -r .version release.json)" >> "$GITHUB_OUTPUT"
+          echo "manifest_url=$(jq -r .manifestUrl release.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Create idempotent numeric tag
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          git fetch --tags --force
+          EXISTING_SHA=""
+          if git rev-parse --verify "refs/tags/$VERSION" >/dev/null 2>&1; then
+            EXISTING_SHA="$(git rev-list -n 1 "$VERSION")"
+          fi
+          ACTION="$(python .github/scripts/release_workflow.py tag-action \
+            --existing-sha "$EXISTING_SHA" \
+            --candidate-sha "$GITHUB_SHA")"
+          if [[ "$ACTION" == "create" ]]; then
+            git config user.name "AJ"
+            git config user.email "ajay.koenig@gmail.com"
+            git tag "$VERSION" "$GITHUB_SHA"
+            git push origin "$VERSION"
+          fi
+
+      - name: Create metadata-only GitHub release
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          MANIFEST_URL: ${{ steps.release.outputs.manifest_url }}
+        run: |
+          gh release view "$VERSION" >/dev/null 2>&1 || \\
+            gh release create "$VERSION" --title "$VERSION" --notes "Firmware manifest: $MANIFEST_URL"

--- a/.github/workflows/master_deploy.yml
+++ b/.github/workflows/master_deploy.yml
@@ -1,124 +1,56 @@
-name: Master Branch Cleanup
-
-# Post-merge cleanup only. Publishing firmware to ossm-firmware/master/ is owned
-# solely by the Version Control workflow (version_bump.yml). Having this workflow
-# also publish caused a race that intermittently wiped master/version.json.
+name: Publish verified master legacy alias
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      release_id:
+        description: Validated immutable main release UUID
+        required: true
+        type: string
+
+permissions:
+  contents: read
 
 jobs:
-  check_changes:
+  alias:
     runs-on: ubuntu-latest
-    outputs:
-      changes_detected: ${{ steps.check_changes.outputs.changes_detected }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Check for changes in Software directory
-        id: check_changes
-        run: |
-          # Compare the previous state of master with the current state after merge
-          # This captures all commits that were merged in the PR
-          if git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | grep -q "^Software/"; then
-            echo "Changes detected in Software directory"
-            echo "changes_detected=true" >> $GITHUB_OUTPUT
-          else
-            echo "No changes in Software directory, skipping build"
-            echo "changes_detected=false" >> $GITHUB_OUTPUT
-          fi
-
-  upload_to_supabase:
-    needs: [check_changes]
-    if: needs.check_changes.outputs.changes_detected == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    environment: firmware-production
     env:
+      FIRMWARE_PUBLISH_TOKEN: ${{ secrets.FIRMWARE_PUBLISH_TOKEN }}
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+      SUPABASE_PROJECT_ID: acjajruwevyyatztbkdf
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+      - uses: supabase/setup-cli@v1
         with:
           version: latest
 
-      - name: Determine merged branch to clean up
-        id: cleanup_registry
+      - name: Download and verify immutable release
+        id: release
         run: |
-          # Get commits between before and after to find merge commits
-          MERGE_COMMITS=$(git log --format="%H %s" ${{ github.event.before }}..${{ github.event.after }} --merges || echo "")
+          python .github/scripts/download_verified_release.py \
+            --release-id "${{ inputs.release_id }}" \
+            --track main \
+            --device ossm \
+            --output firmware
 
-          MERGED_BRANCH=""
-          if [ -n "$MERGE_COMMITS" ]; then
-            # Try to extract branch name from merge commit message
-            # GitHub merge commits typically have format: "Merge pull request #X from owner/branch-name"
-            while IFS= read -r line; do
-              if echo "$line" | grep -q "Merge pull request"; then
-                # Extract branch name from merge commit message
-                BRANCH_NAME=$(echo "$line" | sed -n 's/.*from [^/]*\/\(.*\)/\1/p' | head -1)
-                if [ -n "$BRANCH_NAME" ]; then
-                  # URL encode the branch name
-                  ENCODED_BRANCH=$(echo "$BRANCH_NAME" | sed 's/\//%2F/g' | sed 's/+/%2B/g' | sed 's/ /%20/g')
-                  
-                  # Check if this branch has firmware in the bucket
-                  if supabase storage ls "ss:///ossm-firmware/$ENCODED_BRANCH/manifest.json" --experimental > /dev/null 2>&1; then
-                    MERGED_BRANCH="$ENCODED_BRANCH"
-                    echo "Found merged branch in bucket: $MERGED_BRANCH"
-                    break
-                  fi
-                fi
-              fi
-            done <<< "$MERGE_COMMITS"
-          fi
-
-          # If we didn't find it from merge commits (squash merges never match
-          # that path), scan the bucket for branch folders whose git branch no
-          # longer exists. Discovery is delegated to the rebuild script so
-          # nested folders for slash-named branches (kareem/foo) are found;
-          # it emits URL-encoded branch keys and never emits release channels.
-          if [ -z "$MERGED_BRANCH" ]; then
-            echo "Checking all bucket branch folders for merged branches..."
-            for branch_path in $(bash .github/scripts/rebuild_registry.sh --list-branches); do
-              # Decode branch name (basic URL decode)
-              DECODED_BRANCH=$(echo "$branch_path" | sed 's/%2F/\//g' | sed 's/%2B/+/g' | sed 's/%20/ /g')
-
-              # Check if branch still exists as a remote branch. git ls-remote
-              # exits 0 even when nothing matches, so test its output.
-              if [ -z "$(git ls-remote --heads origin "$DECODED_BRANCH")" ]; then
-                MERGED_BRANCH="$branch_path"
-                echo "Found merged branch (no longer exists): $MERGED_BRANCH"
-                break
-              fi
-            done
-          fi
-
-          if [ -n "$MERGED_BRANCH" ]; then
-            echo "merged_branch=$MERGED_BRANCH" >> $GITHUB_OUTPUT
-            echo "Will clean up branch: $MERGED_BRANCH"
-          else
-            echo "No merged branch found to clean up"
-          fi
-
-      - name: Remove merged branch files from storage
-        if: steps.cleanup_registry.outputs.merged_branch != ''
+      - name: Replace explicit master alias
         run: |
-          MERGED_BRANCH="${{ steps.cleanup_registry.outputs.merged_branch }}"
-          supabase storage rm "ss:///ossm-firmware/${MERGED_BRANCH}" -r --experimental --yes
-          echo "Cleaned up all files for branch: $MERGED_BRANCH"
+          supabase storage rm "ss:///ossm-firmware/master/firmware.bin" "ss:///ossm-firmware/master/partitions.bin" "ss:///ossm-firmware/master/bootloader.bin" \
+            "ss:///ossm-firmware/master/manifest.json" \
+            "ss:///ossm-firmware/master/version.json" --experimental --yes || true
+          [[ ! -f "./firmware/firmware.bin" ]] || supabase storage cp "./firmware/firmware.bin" "ss:///ossm-firmware/master/firmware.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
+          [[ ! -f "./firmware/partitions.bin" ]] || supabase storage cp "./firmware/partitions.bin" "ss:///ossm-firmware/master/partitions.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
+          [[ ! -f "./firmware/bootloader.bin" ]] || supabase storage cp "./firmware/bootloader.bin" "ss:///ossm-firmware/master/bootloader.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
+          sed "s/{{ branchName }}/master/g" .github/artifacts/manifest.json > ./firmware/legacy-manifest.json
+          supabase storage cp ./firmware/legacy-manifest.json "ss:///ossm-firmware/master/manifest.json" --content-type "application/json" --cache-control "no-cache" --experimental
+          supabase storage cp ./firmware/version.json "ss:///ossm-firmware/master/version.json" --content-type "application/json" --cache-control "no-cache" --experimental
 
-  # registry.json is derived state; rebuild it from the bucket on every push to
-  # main (even when cleanup is skipped) so the registry can never stay stale,
-  # corrupt, or missing. `if: always()` keeps this running when
-  # upload_to_supabase is skipped by check_changes.
-  rebuild_registry:
-    needs: [upload_to_supabase]
-    if: always()
+      - name: Summary
+        run: echo "master now points to validated release ${{ inputs.release_id }} (v${{ steps.release.outputs.version }})" >> "$GITHUB_STEP_SUMMARY"
+
+  rebuild-registry:
+    needs: alias
     uses: ./.github/workflows/registry_rebuild.yml
     secrets: inherit

--- a/.github/workflows/publish_firmware.yml
+++ b/.github/workflows/publish_firmware.yml
@@ -1,0 +1,59 @@
+name: Publish immutable firmware candidate
+
+on:
+  push:
+    branches: [main, staging]
+    paths:
+      - "Software/**"
+      - ".github/scripts/publish_immutable_firmware.py"
+      - ".github/scripts/test_publish_immutable_firmware.py"
+      - ".github/scripts/release_workflow.py"
+      - ".github/scripts/test_release_workflow.py"
+      - ".github/workflows/publish_firmware.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: firmware-publish-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name == 'main' && 'firmware-production' || 'firmware-staging' }}
+    env:
+      FIRMWARE_PUBLISH_TOKEN: ${{ secrets.FIRMWARE_PUBLISH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install PlatformIO
+        run: python -m pip install --upgrade platformio
+      - name: Test publisher
+        run: |
+          python .github/scripts/test_publish_immutable_firmware.py
+          python .github/scripts/test_release_workflow.py
+      - name: Run native unit tests
+        working-directory: Software
+        run: pio test -e test
+      - name: Select track build
+        run: python .github/scripts/release_workflow.py configure --branch "$GITHUB_REF_NAME"
+      - name: Build application
+        working-directory: Software
+        run: pio run -e "$PIO_ENV"
+      - name: Publish validating release
+        id: publish
+        run: |
+          python .github/scripts/publish_immutable_firmware.py \
+            --device-type ossm \
+            --track "$TRACK" \
+            --build-sha "$GITHUB_SHA" \
+            --version-file Software/src/constants/Version.h \
+            --artifact "application:Software/.pio/build/$PIO_ENV/firmware.bin:1:true" \
+            --artifact "bootloader:Software/.pio/build/$PIO_ENV/bootloader.bin:2:false" \
+            --artifact "partitions:Software/.pio/build/$PIO_ENV/partitions.bin:3:false"
+      - name: Candidate summary
+        run: echo "Release ${{ steps.publish.outputs.release_id }} is waiting for hardware validation" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pull_request_action.yml
+++ b/.github/workflows/pull_request_action.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - staging
       - release
 
 jobs:

--- a/.github/workflows/pull_request_action.yml
+++ b/.github/workflows/pull_request_action.yml
@@ -127,23 +127,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for documentation changes
+        id: documentation-changes
+        uses: tj-actions/changed-files@v47
+        with:
+          files: Documentation/**
 
       - uses: pnpm/action-setup@v4
+        if: steps.documentation-changes.outputs.any_changed == 'true'
         with:
           version: 10
 
       - uses: actions/setup-node@v4
+        if: steps.documentation-changes.outputs.any_changed == 'true'
         with:
           node-version: '20'
           cache: 'pnpm'
           cache-dependency-path: Documentation/pnpm-lock.yaml
 
       - name: Install dependencies
+        if: steps.documentation-changes.outputs.any_changed == 'true'
         run: |
           cd Documentation
           pnpm install
 
       - name: Validate documentation
+        if: steps.documentation-changes.outputs.any_changed == 'true'
         run: |
           cd Documentation
           pnpm run mint:validate

--- a/.github/workflows/pull_request_action.yml
+++ b/.github/workflows/pull_request_action.yml
@@ -16,14 +16,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check for changes in Software directory
+      - name: Check for firmware or release workflow changes
         id: check_changes
         run: |
-          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -q "^Software/"; then
-            echo "Changes detected in Software directory"
+          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -Eq "^(Software/|\.github/scripts/|\.github/workflows/)"; then
+            echo "Firmware-affecting changes detected"
             echo "changes_detected=true" >> $GITHUB_OUTPUT
           else
-            echo "No changes in Software directory, skipping build"
+            echo "No firmware-affecting changes detected, skipping build"
             echo "changes_detected=false" >> $GITHUB_OUTPUT
           fi
 
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.12"
 
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
@@ -53,7 +53,13 @@ jobs:
       - name: Build PlatformIO Project
         run: |
           cd Software
+          pio run -e staging
           pio run -e production
+
+      - name: Test immutable publisher
+        run: |
+          python .github/scripts/test_publish_immutable_firmware.py
+          python .github/scripts/test_release_workflow.py
 
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v4
@@ -158,148 +164,3 @@ jobs:
         run: |
           cd Documentation
           pnpm run mint:validate
-
-  upload_to_supabase:
-    needs: [check_changes, build]
-    if: needs.check_changes.outputs.changes_detected == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      contents: read
-      deployments: write
-    env:
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Download firmware artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: firmware-bin
-          path: ./firmware
-
-      - name: URL encode branch name
-        id: encode_branch
-        run: |
-          BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
-          URL_ENCODED_BRANCH=$(echo "$BRANCH_NAME" | sed 's/\//%2F/g' | sed 's/+/%2B/g' | sed 's/ /%20/g')
-          echo "encoded_branch=$URL_ENCODED_BRANCH" >> $GITHUB_OUTPUT
-
-      - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
-        with:
-          version: latest
-
-      - name: Get commit hash
-        id: get_commit_hash
-        run: |
-          COMMIT_HASH=$(git rev-parse --short HEAD)
-          echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
-
-      # The registry is no longer read or edited here; it is rebuilt from the
-      # bucket after the firmware upload (see rebuild_registry.sh). This step
-      # only names the archive folder for the firmware currently at the branch
-      # head, derived from git history.
-      - name: Determine old commit
-        id: update_registry
-        run: |
-          BRANCH_PATH="${{ steps.encode_branch.outputs.encoded_branch }}"
-          CURRENT_COMMIT="${{ steps.get_commit_hash.outputs.commit_hash }}"
-
-          OLD_COMMIT=""
-          if supabase storage ls "ss:///ossm-firmware/$BRANCH_PATH/firmware.bin" --experimental > /dev/null 2>&1; then
-            # Find the last commit that modified Software files before current commit
-            OLD_COMMIT=$(git log --format="%h" -1 --skip=1 -- Software/ 2>/dev/null || echo "")
-            if [ -z "$OLD_COMMIT" ]; then
-              # Fallback: use parent commit
-              OLD_COMMIT=$(git rev-parse --short HEAD^ 2>/dev/null || echo "")
-            fi
-            if [ -n "$OLD_COMMIT" ]; then
-              echo "Determined old commit from git: $OLD_COMMIT"
-            else
-              echo "Warning: Could not determine old commit, using current commit"
-              OLD_COMMIT="$CURRENT_COMMIT"
-            fi
-          else
-            echo "No existing firmware found at $BRANCH_PATH, this is first upload"
-          fi
-
-          echo "old_commit=$OLD_COMMIT" >> $GITHUB_OUTPUT
-
-      - name: Move existing firmware out of the way
-        if: steps.update_registry.outputs.old_commit != ''
-        run: |
-          OLD_COMMIT="${{ steps.update_registry.outputs.old_commit }}"
-          BRANCH_PATH="${{ steps.encode_branch.outputs.encoded_branch }}"
-          supabase storage mv "ss:///ossm-firmware/$BRANCH_PATH/firmware.bin" "ss:///ossm-firmware/$BRANCH_PATH/$OLD_COMMIT/firmware.bin" --experimental || true
-          supabase storage mv "ss:///ossm-firmware/$BRANCH_PATH/partitions.bin" "ss:///ossm-firmware/$BRANCH_PATH/$OLD_COMMIT/partitions.bin" --experimental || true
-          supabase storage mv "ss:///ossm-firmware/$BRANCH_PATH/bootloader.bin" "ss:///ossm-firmware/$BRANCH_PATH/$OLD_COMMIT/bootloader.bin" --experimental || true
-          supabase storage mv "ss:///ossm-firmware/$BRANCH_PATH/manifest.json" "ss:///ossm-firmware/$BRANCH_PATH/$OLD_COMMIT/manifest.json" --experimental || true
-        continue-on-error: true
-
-      - name: Upload firmware to Supabase Storage
-        run: |
-          BRANCH_PATH="${{ steps.encode_branch.outputs.encoded_branch }}"
-          # Delete existing files first (ignore errors if they don't exist)
-          supabase storage rm "ss:///ossm-firmware/$BRANCH_PATH/firmware.bin" --experimental --yes || true
-          supabase storage rm "ss:///ossm-firmware/$BRANCH_PATH/partitions.bin" --experimental --yes || true
-          supabase storage rm "ss:///ossm-firmware/$BRANCH_PATH/bootloader.bin" --experimental --yes || true
-          # Upload new files
-          supabase storage cp ./firmware/firmware.bin "ss:///ossm-firmware/$BRANCH_PATH/firmware.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
-          supabase storage cp ./firmware/partitions.bin "ss:///ossm-firmware/$BRANCH_PATH/partitions.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
-          supabase storage cp ./firmware/bootloader.bin "ss:///ossm-firmware/$BRANCH_PATH/bootloader.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
-
-      - name: Create and upload manifest.json
-        run: |
-          BRANCH_PATH="${{ steps.encode_branch.outputs.encoded_branch }}"
-          # Create a temporary manifest file with the branch name replaced
-          cat .github/artifacts/manifest.json | sed "s/{{ branchName }}/$BRANCH_PATH/g" > ./manifest.json
-          # Delete existing manifest if it exists
-          supabase storage rm "ss:///ossm-firmware/$BRANCH_PATH/manifest.json" --experimental --yes || true
-          # Upload the manifest file to Supabase Storage
-          supabase storage cp ./manifest.json "ss:///ossm-firmware/$BRANCH_PATH/manifest.json" --content-type "application/json" --cache-control "no-cache" --experimental
-
-      # Runs before the GitHub Deployment is created so the deployment's
-      # ?branch= flasher link resolves against a registry that already lists
-      # this branch.
-      - name: Rebuild registry from bucket contents
-        run: bash .github/scripts/rebuild_registry.sh
-
-      - name: Create GitHub Deployment
-        id: create_deployment
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const deployment = await github.rest.repos.createDeployment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: context.payload.pull_request ? context.payload.pull_request.head.ref : context.ref,
-              environment: 'firmware',
-              auto_merge: false,
-              required_contexts: [],
-              description: 'OSSM Firmware Deployment'
-            });
-
-            return { id: deployment.data.id };
-
-      - name: Create Deployment Status
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const deploymentId = ${{ steps.create_deployment.outputs.result }}.id;
-            const flashUrl = 'https://docs.researchanddesire.com/ossm/tools/web-flasher?branch=${{ steps.encode_branch.outputs.encoded_branch }}';
-
-            await github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: deploymentId,
-              state: 'success',
-              environment_url: flashUrl,
-              log_url: flashUrl,
-              description: 'Firmware ready to flash'
-            });

--- a/.github/workflows/pull_request_action.yml
+++ b/.github/workflows/pull_request_action.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - staging
-      - release
 
 jobs:
   check_changes:

--- a/.github/workflows/release_alpha.yml
+++ b/.github/workflows/release_alpha.yml
@@ -1,60 +1,51 @@
-name: Release Master as Alpha
+name: Publish verified alpha legacy alias
 
 on:
   workflow_dispatch:
+    inputs:
+      release_id:
+        description: Validated immutable release UUID
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
-  release-alpha:
+  alias:
     runs-on: ubuntu-latest
+    environment: firmware-staging
     env:
+      FIRMWARE_PUBLISH_TOKEN: ${{ secrets.FIRMWARE_PUBLISH_TOKEN }}
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+      SUPABASE_PROJECT_ID: meuaxbjzqrszxdvmacug
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+      - uses: supabase/setup-cli@v1
         with:
           version: latest
 
-      - name: Download files from master/
+      - name: Download and verify immutable release
+        id: release
         run: |
-          mkdir -p ./firmware
-          supabase storage cp "ss:///ossm-firmware/master/firmware.bin" ./firmware/firmware.bin --experimental
-          supabase storage cp "ss:///ossm-firmware/master/partitions.bin" ./firmware/partitions.bin --experimental
-          supabase storage cp "ss:///ossm-firmware/master/bootloader.bin" ./firmware/bootloader.bin --experimental
-          supabase storage cp "ss:///ossm-firmware/master/version.json" ./firmware/version.json --experimental
+          python .github/scripts/download_verified_release.py \\
+            --release-id "${{ inputs.release_id }}" \\
+            --track staging \\
+            --device ossm \\
+            --output firmware
 
-      - name: Get Version
-        id: get_version
+      - name: Replace explicit alpha alias
         run: |
-          VERSION=$(jq -r .version ./firmware/version.json)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Releasing version $VERSION to alpha"
-
-      - name: Upload files to alpha/
-        run: |
-          # Delete existing files in alpha/
-          supabase storage rm "ss:///ossm-firmware/alpha/firmware.bin" "ss:///ossm-firmware/alpha/partitions.bin" "ss:///ossm-firmware/alpha/bootloader.bin" "ss:///ossm-firmware/alpha/manifest.json" "ss:///ossm-firmware/alpha/version.json" --experimental --yes || true
-          
-          # Upload firmware binaries
-          supabase storage cp ./firmware/firmware.bin "ss:///ossm-firmware/alpha/firmware.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
-          supabase storage cp ./firmware/partitions.bin "ss:///ossm-firmware/alpha/partitions.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
-          supabase storage cp ./firmware/bootloader.bin "ss:///ossm-firmware/alpha/bootloader.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
-          
-          # Create and upload manifest.json for alpha
-          cat .github/artifacts/manifest.json | sed "s/{{ branchName }}/alpha/g" > ./manifest.json
-          supabase storage cp ./manifest.json "ss:///ossm-firmware/alpha/manifest.json" --content-type "application/json" --cache-control "no-cache" --experimental
-          
-          # Upload version.json
+          supabase storage rm "ss:///ossm-firmware/alpha/firmware.bin" "ss:///ossm-firmware/alpha/partitions.bin" "ss:///ossm-firmware/alpha/bootloader.bin" \\
+            "ss:///ossm-firmware/alpha/manifest.json" \\
+            "ss:///ossm-firmware/alpha/version.json" --experimental --yes || true
+          [[ ! -f "./firmware/firmware.bin" ]] || supabase storage cp "./firmware/firmware.bin" "ss:///ossm-firmware/alpha/firmware.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
+          [[ ! -f "./firmware/partitions.bin" ]] || supabase storage cp "./firmware/partitions.bin" "ss:///ossm-firmware/alpha/partitions.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
+          [[ ! -f "./firmware/bootloader.bin" ]] || supabase storage cp "./firmware/bootloader.bin" "ss:///ossm-firmware/alpha/bootloader.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
+          sed "s/{{ branchName }}/alpha/g" .github/artifacts/manifest.json > ./firmware/legacy-manifest.json
+          supabase storage cp ./firmware/legacy-manifest.json "ss:///ossm-firmware/alpha/manifest.json" --content-type "application/json" --cache-control "no-cache" --experimental
           supabase storage cp ./firmware/version.json "ss:///ossm-firmware/alpha/version.json" --content-type "application/json" --cache-control "no-cache" --experimental
 
       - name: Summary
-        run: |
-          echo "✅ Released v${{ steps.get_version.outputs.version }} to alpha channel"
-          echo ""
-          echo "Firmware URL: https://acjajruwevyyatztbkdf.supabase.co/storage/v1/object/public/ossm-firmware/alpha/"
+        run: echo "alpha now points to validated release ${{ inputs.release_id }} (v${{ steps.release.outputs.version }})" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -1,76 +1,61 @@
-name: Release Alpha as Production
+name: Publish verified production legacy alias
 
 on:
   workflow_dispatch:
+    inputs:
+      release_id:
+        description: Validated immutable release UUID
+        required: true
+        type: string
 
 permissions:
   contents: read
-  id-token: write # required for the AWS OIDC login (legacy CloudFront mirror)
 
 jobs:
-  release-production:
+  alias:
     runs-on: ubuntu-latest
+    environment: firmware-production
     env:
+      FIRMWARE_PUBLISH_TOKEN: ${{ secrets.FIRMWARE_PUBLISH_TOKEN }}
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+      SUPABASE_PROJECT_ID: acjajruwevyyatztbkdf
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+      - uses: supabase/setup-cli@v1
         with:
           version: latest
 
-      - name: Download files from alpha/
+      - name: Download and verify immutable release
+        id: release
         run: |
-          mkdir -p ./firmware
-          supabase storage cp "ss:///ossm-firmware/alpha/firmware.bin" ./firmware/firmware.bin --experimental
-          supabase storage cp "ss:///ossm-firmware/alpha/partitions.bin" ./firmware/partitions.bin --experimental
-          supabase storage cp "ss:///ossm-firmware/alpha/bootloader.bin" ./firmware/bootloader.bin --experimental
-          supabase storage cp "ss:///ossm-firmware/alpha/version.json" ./firmware/version.json --experimental
+          python .github/scripts/download_verified_release.py \\
+            --release-id "${{ inputs.release_id }}" \\
+            --track main \\
+            --device ossm \\
+            --output firmware
 
-      - name: Get Version
-        id: get_version
+      - name: Replace explicit production alias
         run: |
-          VERSION=$(jq -r .version ./firmware/version.json)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Releasing version $VERSION to production"
-
-      - name: Upload files to production/
-        run: |
-          # Delete existing files in production/
-          supabase storage rm "ss:///ossm-firmware/production/firmware.bin" "ss:///ossm-firmware/production/partitions.bin" "ss:///ossm-firmware/production/bootloader.bin" "ss:///ossm-firmware/production/manifest.json" "ss:///ossm-firmware/production/version.json" --experimental --yes || true
-          
-          # Upload firmware binaries
-          supabase storage cp ./firmware/firmware.bin "ss:///ossm-firmware/production/firmware.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
-          supabase storage cp ./firmware/partitions.bin "ss:///ossm-firmware/production/partitions.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
-          supabase storage cp ./firmware/bootloader.bin "ss:///ossm-firmware/production/bootloader.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
-          
-          # Create and upload manifest.json for production
-          cat .github/artifacts/manifest.json | sed "s/{{ branchName }}/production/g" > ./manifest.json
-          supabase storage cp ./manifest.json "ss:///ossm-firmware/production/manifest.json" --content-type "application/json" --cache-control "no-cache" --experimental
-          
-          # Upload version.json
+          supabase storage rm "ss:///ossm-firmware/production/firmware.bin" "ss:///ossm-firmware/production/partitions.bin" "ss:///ossm-firmware/production/bootloader.bin" \\
+            "ss:///ossm-firmware/production/manifest.json" \\
+            "ss:///ossm-firmware/production/version.json" --experimental --yes || true
+          [[ ! -f "./firmware/firmware.bin" ]] || supabase storage cp "./firmware/firmware.bin" "ss:///ossm-firmware/production/firmware.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
+          [[ ! -f "./firmware/partitions.bin" ]] || supabase storage cp "./firmware/partitions.bin" "ss:///ossm-firmware/production/partitions.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
+          [[ ! -f "./firmware/bootloader.bin" ]] || supabase storage cp "./firmware/bootloader.bin" "ss:///ossm-firmware/production/bootloader.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
+          sed "s/{{ branchName }}/production/g" .github/artifacts/manifest.json > ./firmware/legacy-manifest.json
+          supabase storage cp ./firmware/legacy-manifest.json "ss:///ossm-firmware/production/manifest.json" --content-type "application/json" --cache-control "no-cache" --experimental
           supabase storage cp ./firmware/version.json "ss:///ossm-firmware/production/version.json" --content-type "application/json" --cache-control "no-cache" --experimental
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
 
-      - name: Mirror firmware to legacy CloudFront origin (S3)
-        run: |
-          # Old WiFi-OTA devices (e.g. 1.0.16) download from the legacy CloudFront
-          # path, not Supabase. Refresh it on every prod promotion so that fleet
-          # stays current. Bucket "ossm-update" is the origin behind
-          # d2sy3zdr3r1gt5.cloudfront.net (confirmed via matching x-amz-version-id).
-          aws s3 cp ./firmware/firmware.bin s3://ossm-update/firmware.bin --acl public-read
+      - name: Mirror verified application to CloudFront origin
+        run: aws s3 cp ./firmware/firmware.bin s3://ossm-update/firmware.bin --acl public-read
 
       - name: Summary
-        run: |
-          echo "✅ Released v${{ steps.get_version.outputs.version }} to production channel"
-          echo ""
-          echo "Supabase: https://acjajruwevyyatztbkdf.supabase.co/storage/v1/object/public/ossm-firmware/production/"
-          echo "Legacy:   https://d2sy3zdr3r1gt5.cloudfront.net/firmware.bin"
+        run: echo "production now points to validated release ${{ inputs.release_id }} (v${{ steps.release.outputs.version }})" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -1,192 +1,51 @@
-name: Version Control
+name: Prepare firmware release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Semantic version increment
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
-  update-version:
+  prepare:
     runs-on: ubuntu-latest
-    env:
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
     steps:
-      - name: Check if sender is a bot
-        id: bot_check
-        run: |
-          if [[ "${{ github.event.sender.login }}" == "github-actions[bot]" || "${{ github.event.sender.login }}" == "rad-version-control[bot]" ]]; then
-            echo "is_bot=true" >> $GITHUB_OUTPUT
-            echo "Exiting early: sender is ${{ github.event.sender.login }}"
-          else
-            echo "is_bot=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Checkout code
-        if: ${{ steps.bot_check.outputs.is_bot != 'true' }}
+      - name: Checkout staging
         uses: actions/checkout@v4
         with:
+          ref: staging
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
-      - name: Exit early if only markdown files changed
-        if: ${{ steps.bot_check.outputs.is_bot != 'true' }}
-        id: check_changes
+      - name: Prepare version and changelog draft
+        id: version
         run: |
-          # Get list of changed files in the last commit
-          CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
-          echo "Changed files: $CHANGED_FILES"
+          python scripts/prepare_version.py \\
+            --header Software/src/constants/Version.h \\
+            --changelog Documentation/ossm/guides/changelog/overview.mdx \\
+            --version-json version.json \\
+            --bump "${{ inputs.bump }}"
 
-          # Check if all changed files are markdown files
-          NON_MD_FILES=$(echo "$CHANGED_FILES" | grep -v '\.md$' | grep -v '^$')
-
-          if [ -z "$NON_MD_FILES" ] && [ -n "$CHANGED_FILES" ]; then
-            echo "Only markdown files changed, skipping version bump"
-            echo "skip=true" >> $GITHUB_OUTPUT
-          else
-            echo "Non-markdown files changed, proceeding with version bump"
-            echo "skip=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Setup Python
-        if: ${{ steps.bot_check.outputs.is_bot != 'true' && steps.check_changes.outputs.skip != 'true' }}
-        uses: actions/setup-python@v5
+      - name: Open staging release-preparation PR
+        uses: peter-evans/create-pull-request@v7
         with:
-          python-version: "3.9"
+          token: ${{ secrets.GH_PAT || github.token }}
+          base: staging
+          branch: release/prepare-${{ steps.version.outputs.version }}
+          delete-branch: true
+          commit-message: "Prepare firmware ${{ steps.version.outputs.version }}"
+          title: "Prepare firmware ${{ steps.version.outputs.version }}"
+          body: |
+            Prepares semantic version ${{ steps.version.outputs.version }} for staging validation.
 
-      - name: Install PlatformIO Core
-        if: ${{ steps.bot_check.outputs.is_bot != 'true' && steps.check_changes.outputs.skip != 'true' }}
-        run: pip install --upgrade platformio
-
-      - name: Setup Supabase CLI
-        if: ${{ steps.bot_check.outputs.is_bot != 'true' && steps.check_changes.outputs.skip != 'true' }}
-        uses: supabase/setup-cli@v1
-        with:
-          version: latest
-
-      - name: Get next version
-        if: ${{ steps.bot_check.outputs.is_bot != 'true' && steps.check_changes.outputs.skip != 'true' }}
-        id: get_next_version
-        run: |
-          chmod +x ./Software/scripts/get_next_version.sh
-          echo "Getting next version"
-          COMMIT_MSG="$(git log -1 --pretty=%B)"
-          echo "COMMIT_MSG=$COMMIT_MSG"
-          ./Software/scripts/get_next_version.sh "$COMMIT_MSG"
-        shell: bash
-
-      - name: Update version
-        if: ${{ steps.bot_check.outputs.is_bot != 'true' && steps.check_changes.outputs.skip != 'true' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
-          NEXT_VERSION: ${{ steps.get_next_version.outputs.NEXT_VERSION }}
-        id: version_update
-        run: |
-          chmod +x ./Software/scripts/version_bump.sh
-          ./Software/scripts/version_bump.sh "$NEXT_VERSION"
-
-      - name: Build PlatformIO Project
-        if: ${{ steps.bot_check.outputs.is_bot != 'true' && steps.check_changes.outputs.skip != 'true' }}
-        run: |
-          cd Software
-          pio run -e production
-
-      - name: Install Cursor CLI
-        if: ${{ steps.bot_check.outputs.is_bot != 'true' && steps.check_changes.outputs.skip != 'true' }}
-        run: |
-          curl https://cursor.com/install -fsS | bash
-          echo "$HOME/.cursor/bin" >> $GITHUB_PATH
-
-      - name: Update changelog
-        if: ${{ steps.bot_check.outputs.is_bot != 'true' && steps.check_changes.outputs.skip != 'true' }}
-        env:
-          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
-          BUMP_TYPE: ${{ steps.get_next_version.outputs.BUMP_TYPE }}
-          NEXT_VERSION: ${{ steps.get_next_version.outputs.NEXT_VERSION }}
-        run: |
-          CHANGELOG_PATH="Documentation/ossm/guides/changelog/overview.mdx"
-          
-          # Get the diff of changes (excluding version files and markdown)
-          git diff HEAD~1 HEAD --unified=3 -- . ':!**/Version.h' ':!**/version.json' ':!*.md' > /tmp/changes.diff || echo "No diff available" > /tmp/changes.diff
-          
-          # Build the prompt using heredoc
-          if [[ "$BUMP_TYPE" == "patch" ]]; then
-            cat > /tmp/prompt.txt << 'PROMPT_END'
-          You are updating the OSSM (Open Source Sex Machine) changelog. A patch version bump has occurred.
-          Analyze the diff file at /tmp/changes.diff and append patch notes to the MOST RECENT <Update> section in the changelog. Do NOT create a new <Update> section.
-          Rules: Add concise bullet points describing the changes. Focus on user-facing changes and bug fixes. Use format: **Feature/Fix name** — Brief description
-          PROMPT_END
-          else
-            cat > /tmp/prompt.txt << 'PROMPT_END'
-          You are updating the OSSM (Open Source Sex Machine) changelog. A major or minor version bump has occurred.
-          Analyze the diff file at /tmp/changes.diff and create a NEW <Update> section at the TOP of the changelog content (after the frontmatter and intro paragraph).
-          Rules: Create a new <Update label="Version X.Y.Z" description="Brief description"> section. Add a ## heading describing the main theme. Add bullet points for changes. Place the new <Update> section BEFORE any existing <Update> sections.
-          PROMPT_END
-          fi
-          
-          # Add version and path info
-          echo "Version: ${NEXT_VERSION}" >> /tmp/prompt.txt
-          echo "Changelog file: ${CHANGELOG_PATH}" >> /tmp/prompt.txt
-          echo "Diff file: /tmp/changes.diff" >> /tmp/prompt.txt
-          
-          PROMPT=$(cat /tmp/prompt.txt)
-          agent --print --model opus-4.5-thinking --force --workspace "$(pwd)" "$PROMPT" || echo "Changelog update skipped"
-
-      - name: Upload firmware to Supabase master/
-        if: ${{ steps.bot_check.outputs.is_bot != 'true' && steps.check_changes.outputs.skip != 'true' }}
-        run: |
-          # Delete existing files
-          supabase storage rm "ss:///ossm-firmware/master/firmware.bin" --experimental --yes || true
-          supabase storage rm "ss:///ossm-firmware/master/partitions.bin" --experimental --yes || true
-          supabase storage rm "ss:///ossm-firmware/master/bootloader.bin" --experimental --yes || true
-          supabase storage rm "ss:///ossm-firmware/master/manifest.json" --experimental --yes || true
-          supabase storage rm "ss:///ossm-firmware/master/version.json" --experimental --yes || true
-          
-          # Upload firmware binaries
-          supabase storage cp ./Software/.pio/build/production/firmware.bin "ss:///ossm-firmware/master/firmware.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
-          supabase storage cp ./Software/.pio/build/production/partitions.bin "ss:///ossm-firmware/master/partitions.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
-          supabase storage cp ./Software/.pio/build/production/bootloader.bin "ss:///ossm-firmware/master/bootloader.bin" --content-type "application/octet-stream" --cache-control "no-cache" --experimental
-          
-          # Create and upload manifest.json for master
-          cat .github/artifacts/manifest.json | sed "s/{{ branchName }}/master/g" > ./manifest.json
-          supabase storage cp ./manifest.json "ss:///ossm-firmware/master/manifest.json" --content-type "application/json" --cache-control "no-cache" --experimental
-          
-          # Upload version.json
-          supabase storage cp ./version.json "ss:///ossm-firmware/master/version.json" --content-type "application/json" --cache-control "no-cache" --experimental
-
-      - name: Merge origin/main with -X ours strategy
-        if: ${{ steps.bot_check.outputs.is_bot != 'true' && steps.check_changes.outputs.skip != 'true' }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin main
-          git merge origin/main -X ours --no-edit
-
-      - name: Commit, tag, and push to main
-        if: ${{ steps.bot_check.outputs.is_bot != 'true' && steps.check_changes.outputs.skip != 'true' }}
-        env:
-          NEXT_VERSION: ${{ steps.get_next_version.outputs.NEXT_VERSION }}
-          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "AUTO: Version bump ${NEXT_VERSION}" || echo "No changes to commit"
-          git tag "$NEXT_VERSION"
-          git push origin main
-          git push origin "$NEXT_VERSION"
-
-      - name: Set success status for bot commits
-        if: ${{ steps.bot_check.outputs.is_bot == 'true' }}
-        run: |
-          echo "No version bump needed - commit was from bot (${{ github.event.sender.login }})"
-          exit 0
-
-      - name: Set success status for markdown-only changes
-        if: ${{ steps.check_changes.outputs.skip == 'true' }}
-        run: |
-          echo "No version bump needed - only markdown files changed"
-          exit 0
+            Replace the changelog draft line before merging. Artifact publication begins only after this PR is merged into staging.
+          labels: release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md
+
+## Branch and Release Policy
+
+- Persistent branches are lowercase `staging` and `main`.
+- Start feature and release work from `staging` and merge it into `staging` first.
+- Promote normal releases with a `staging` to `main` pull request only after every required build, unit, integration, artifact-verification, and OSSM hardware validation succeeds.
+- Only urgent production bug fixes may target `main` directly. Merge each main hotfix back into `staging` immediately.
+- Use matching branch names and linked pull requests for changes spanning RAD App or another firmware repository.
+- Staging firmware reports the `staging` track and checks `https://staging.researchanddesire.com`. Main firmware reports `main` and checks `https://dashboard.researchanddesire.com`.
+- Firmware is update-eligible only after its immutable Supabase artifacts and all required validation records verify. Missing hardware runners leave a release in `validating`; never bypass a gate.
+
+## Development Safety
+
+- Preserve the dedicated TLS/update task and MQTT pause behavior. Keep update protocol, checksum, reboot, and rollback behavior covered by native tests.
+- Never commit credentials, local build products, or generated secrets.

--- a/Documentation/ossm/Software/architecture/folder-structure.mdx
+++ b/Documentation/ossm/Software/architecture/folder-structure.mdx
@@ -313,7 +313,7 @@ The `platformio.ini` file defines build environments:
   Customize motion parameters, pins, and settings.
 </Card>
 
-<Card title="Display Service" icon="display" href="/ossm/Software/getting-started/display">
+<Card title="Display Service" icon="display" href="/ossm/Software/display/display-service">
   Learn about the thread-safe display API.
 </Card>
 

--- a/Documentation/ossm/guides/changelog/overview.mdx
+++ b/Documentation/ossm/guides/changelog/overview.mdx
@@ -8,6 +8,11 @@ Stay up to date with the latest changes to the Open Source Sex Machine. This cha
 
 <Update label="Version 0.0.0" description="Placeholder Release">
 
+### v1.0.35
+
+- **Database-controlled updates** — The updater reports the device track and build, follows the database assignment, and installs only checksum-verified immutable Supabase artifacts over validated HTTPS.
+- **Update-task isolation** — MQTT remains paused during the dedicated TLS task and update checks never invoke motor control.
+
 ## Placeholder Release
 
 This is a placeholder entry for future OSSM updates. See the [detailed release notes](/ossm/guides/changelog/v0.0.0) for more information.

--- a/Documentation/snippets/shared/device-flasher.jsx
+++ b/Documentation/snippets/shared/device-flasher.jsx
@@ -1,7 +1,3 @@
-import { useState, useEffect, useRef } from 'react';
-
-
-
 export const DeviceFlasher = ({ device = 'ossm' }) => {
   const DEVICE_CONFIGS = {
     ossm: {

--- a/Software/firmware_build_metadata.py
+++ b/Software/firmware_build_metadata.py
@@ -1,0 +1,9 @@
+Import("env")
+
+import os
+
+env.Append(
+    CPPDEFINES=[
+        ("FIRMWARE_BUILD_SHA", env.StringifyMacro(os.getenv("GITHUB_SHA", "unknown")))
+    ]
+)

--- a/Software/lib/FirmwareUpdateProtocol/src/FirmwareUpdateProtocol.h
+++ b/Software/lib/FirmwareUpdateProtocol/src/FirmwareUpdateProtocol.h
@@ -1,0 +1,230 @@
+#pragma once
+
+#include <ArduinoJson.h>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <string>
+
+namespace firmware {
+
+constexpr int PROTOCOL_VERSION = 1;
+constexpr std::size_t MAX_ARTIFACTS = 8;
+
+struct DeviceReport {
+    std::string deviceType;
+    std::string deviceId;
+    std::string reportedTrack;
+    std::string currentVersion;
+    std::string currentBuild;
+    std::string firmwareHash;
+    std::string chip;
+    std::string hardwareRevision;
+    std::uint32_t flashSizeBytes = 0;
+    std::string partitionLayout;
+};
+
+struct Artifact {
+    std::string role;
+    std::string url;
+    std::string sha256;
+    std::uint32_t sizeBytes = 0;
+    int installOrder = 0;
+};
+
+struct Decision {
+    bool updateAvailable = false;
+    std::string reportedTrack;
+    std::string assignedTrack;
+    bool trackChanged = false;
+    std::string currentVersion;
+    std::string targetVersion;
+    std::string nextHopVersion;
+    std::string releaseId;
+    std::string kind;
+    std::array<Artifact, MAX_ARTIFACTS> artifacts{};
+    std::size_t artifactCount = 0;
+    std::uint32_t nextCheckSeconds = 0;
+};
+
+inline bool isTrack(const std::string &value) {
+    return value == "main" || value == "staging";
+}
+
+inline bool isSemver(const std::string &value) {
+    int dots = 0;
+    bool digitInPart = false;
+    for (const char character : value) {
+        if (character == '.') {
+            if (!digitInPart || ++dots > 2) return false;
+            digitInPart = false;
+        } else if (character == '+' || character == '-') {
+            break;
+        } else if (std::isdigit(static_cast<unsigned char>(character))) {
+            digitInPart = true;
+        } else {
+            return false;
+        }
+    }
+    return dots == 2 && digitInPart;
+}
+
+inline bool isSha256(const std::string &value) {
+    return value.size() == 64 &&
+           std::all_of(value.begin(), value.end(), [](const char character) {
+               return std::isxdigit(static_cast<unsigned char>(character));
+           });
+}
+
+inline bool isArtifactRole(const std::string &role) {
+    return role == "application" || role == "filesystem" ||
+           role == "bootloader" || role == "partitions" ||
+           role == "manifest";
+}
+
+inline bool isHttpsArtifactUrl(const std::string &url,
+                               const std::string &expectedBucket) {
+    const std::string prefix = "https://";
+    const std::string hostSuffix = ".supabase.co";
+    const std::string storagePath =
+        "/storage/v1/object/public/" + expectedBucket +
+        "/releases/";
+    if (url.rfind(prefix, 0) != 0 || url.find('@') != std::string::npos ||
+        url.find('#') != std::string::npos || url.find('?') != std::string::npos) {
+        return false;
+    }
+    const auto hostEnd = url.find('/', prefix.size());
+    if (hostEnd == std::string::npos) return false;
+    const std::string host = url.substr(prefix.size(), hostEnd - prefix.size());
+    if (host.size() <= hostSuffix.size() ||
+        host.compare(host.size() - hostSuffix.size(), hostSuffix.size(),
+                     hostSuffix) != 0 ||
+        host.find(':') != std::string::npos) {
+        return false;
+    }
+    return url.compare(hostEnd, storagePath.size(), storagePath) == 0;
+}
+
+inline std::string serializeReport(const DeviceReport &report) {
+    JsonDocument document;
+    document["deviceType"] = report.deviceType;
+    document["deviceId"] = report.deviceId;
+    document["reportedTrack"] = report.reportedTrack;
+    document["currentVersion"] = report.currentVersion;
+    if (!report.currentBuild.empty())
+        document["currentBuild"] = report.currentBuild;
+    if (!report.firmwareHash.empty())
+        document["firmwareHash"] = report.firmwareHash;
+    if (!report.chip.empty()) document["chip"] = report.chip;
+    if (!report.hardwareRevision.empty())
+        document["hardwareRevision"] = report.hardwareRevision;
+    if (report.flashSizeBytes > 0)
+        document["flashSizeBytes"] = report.flashSizeBytes;
+    if (!report.partitionLayout.empty())
+        document["partitionLayout"] = report.partitionLayout;
+    std::string output;
+    serializeJson(document, output);
+    return output;
+}
+
+inline bool readRequiredString(JsonVariantConst value, std::string &output) {
+    if (!value.is<const char *>()) return false;
+    output = value.as<const char *>();
+    return !output.empty();
+}
+
+inline bool readNullableVersion(JsonVariantConst value, std::string &output) {
+    if (value.isNull()) {
+        output.clear();
+        return true;
+    }
+    return readRequiredString(value, output) && isSemver(output);
+}
+
+inline bool parseDecision(const std::string &payload,
+                          const std::string &expectedDeviceType,
+                          Decision &decision, std::string &error) {
+    JsonDocument document;
+    const auto jsonError = deserializeJson(document, payload);
+    if (jsonError) {
+        error = "invalid JSON";
+        return false;
+    }
+
+    Decision parsed;
+    if (!document["updateAvailable"].is<bool>() ||
+        !document["trackChanged"].is<bool>() ||
+        !document["nextCheckSeconds"].is<std::uint32_t>() ||
+        !readRequiredString(document["reportedTrack"], parsed.reportedTrack) ||
+        !readRequiredString(document["assignedTrack"], parsed.assignedTrack) ||
+        !readRequiredString(document["currentVersion"], parsed.currentVersion) ||
+        !readNullableVersion(document["targetVersion"], parsed.targetVersion) ||
+        !readNullableVersion(document["nextHopVersion"], parsed.nextHopVersion) ||
+        !isTrack(parsed.reportedTrack) || !isTrack(parsed.assignedTrack) ||
+        !isSemver(parsed.currentVersion)) {
+        error = "missing or invalid response fields";
+        return false;
+    }
+
+    parsed.updateAvailable = document["updateAvailable"].as<bool>();
+    parsed.trackChanged = document["trackChanged"].as<bool>();
+    parsed.nextCheckSeconds = document["nextCheckSeconds"].as<std::uint32_t>();
+    if (!parsed.updateAvailable) {
+        if (!document["update"].isNull()) {
+            error = "no-update response contains update data";
+            return false;
+        }
+        decision = parsed;
+        return true;
+    }
+
+    JsonObjectConst update = document["update"].as<JsonObjectConst>();
+    JsonArrayConst artifacts = update["artifacts"].as<JsonArrayConst>();
+    if (update.isNull() || artifacts.isNull() || artifacts.size() == 0 ||
+        artifacts.size() > MAX_ARTIFACTS ||
+        !readRequiredString(update["releaseId"], parsed.releaseId) ||
+        !readRequiredString(update["kind"], parsed.kind) ||
+        (parsed.kind != "firmware" && parsed.kind != "migration") ||
+        parsed.nextHopVersion.empty()) {
+        error = "invalid update metadata";
+        return false;
+    }
+
+    const std::string expectedBucket = expectedDeviceType + "-firmware";
+    std::array<bool, MAX_ARTIFACTS> seenOrders{};
+    for (JsonObjectConst item : artifacts) {
+        Artifact artifact;
+        if (!readRequiredString(item["role"], artifact.role) ||
+            !readRequiredString(item["url"], artifact.url) ||
+            !readRequiredString(item["sha256"], artifact.sha256) ||
+            !item["sizeBytes"].is<std::uint32_t>() ||
+            !item["installOrder"].is<int>() ||
+            !isArtifactRole(artifact.role) || !isSha256(artifact.sha256) ||
+            !isHttpsArtifactUrl(artifact.url, expectedBucket)) {
+            error = "invalid artifact";
+            return false;
+        }
+        artifact.sizeBytes = item["sizeBytes"].as<std::uint32_t>();
+        artifact.installOrder = item["installOrder"].as<int>();
+        if (artifact.sizeBytes == 0 || artifact.installOrder < 0 ||
+            artifact.installOrder >= static_cast<int>(MAX_ARTIFACTS) ||
+            seenOrders[artifact.installOrder]) {
+            error = "invalid artifact size or order";
+            return false;
+        }
+        seenOrders[artifact.installOrder] = true;
+        parsed.artifacts[parsed.artifactCount++] = artifact;
+    }
+
+    std::sort(parsed.artifacts.begin(),
+              parsed.artifacts.begin() + parsed.artifactCount,
+              [](const Artifact &left, const Artifact &right) {
+                  return left.installOrder < right.installOrder;
+              });
+    decision = parsed;
+    return true;
+}
+
+}  // namespace firmware

--- a/Software/lib/FirmwareUpdateProtocol/src/FirmwareUpdateRuntime.h
+++ b/Software/lib/FirmwareUpdateProtocol/src/FirmwareUpdateRuntime.h
@@ -1,0 +1,193 @@
+#pragma once
+
+#include "FirmwareUpdateProtocol.h"
+
+#if defined(ARDUINO_ARCH_ESP32)
+
+#include <Arduino.h>
+#include <Update.h>
+#include <esp_crt_bundle.h>
+#include <esp_http_client.h>
+#include <mbedtls/sha256.h>
+
+#if defined(FIRMWARE_USE_IDF_CRT_BUNDLE)
+#define FIRMWARE_CRT_BUNDLE_ATTACH esp_crt_bundle_attach
+#else
+#define FIRMWARE_CRT_BUNDLE_ATTACH arduino_esp_crt_bundle_attach
+#endif
+
+namespace firmware {
+
+inline bool postCheck(const char *apiBaseUrl, const DeviceReport &report,
+                      Decision &decision, String &error) {
+    String url = apiBaseUrl;
+    if (url.endsWith("/")) url.remove(url.length() - 1);
+    url += "/api/firmware/v1/check";
+    const std::string body = serializeReport(report);
+
+    esp_http_client_config_t config = {};
+    config.url = url.c_str();
+    config.method = HTTP_METHOD_POST;
+    config.timeout_ms = 30000;
+    config.buffer_size = 4096;
+    config.buffer_size_tx = 2048;
+    config.crt_bundle_attach = FIRMWARE_CRT_BUNDLE_ATTACH;
+
+    esp_http_client_handle_t client = esp_http_client_init(&config);
+    if (client == nullptr) {
+        error = "failed to initialize HTTPS client";
+        return false;
+    }
+    esp_http_client_set_header(client, "Content-Type", "application/json");
+    esp_http_client_set_header(client, "Accept-Encoding", "identity");
+
+    bool success = false;
+    if (esp_http_client_open(client, body.size()) != ESP_OK ||
+        esp_http_client_write(client, body.data(), body.size()) !=
+            static_cast<int>(body.size())) {
+        error = "firmware check request failed";
+    } else {
+        esp_http_client_fetch_headers(client);
+        const int status = esp_http_client_get_status_code(client);
+        String response;
+        char buffer[512];
+        int read = 0;
+        while ((read = esp_http_client_read(client, buffer, sizeof(buffer))) > 0) {
+            if (response.length() + read > 32768) {
+                error = "firmware response is too large";
+                response.clear();
+                break;
+            }
+            response.concat(buffer, read);
+        }
+        if (status != 200) {
+            error = "firmware check returned HTTP " + String(status);
+        } else if (!response.isEmpty()) {
+            std::string parseError;
+            success = parseDecision(response.c_str(), report.deviceType,
+                                    decision, parseError);
+            if (!success) error = parseError.c_str();
+        }
+    }
+
+    esp_http_client_close(client);
+    esp_http_client_cleanup(client);
+    if (success &&
+        (decision.reportedTrack != report.reportedTrack ||
+         decision.currentVersion != report.currentVersion ||
+         decision.trackChanged !=
+             (decision.reportedTrack != decision.assignedTrack))) {
+        error = "firmware response does not match device report";
+        return false;
+    }
+    return success;
+}
+
+inline std::string sha256Hex(const unsigned char digest[32]) {
+    static const char HEX_DIGITS[] = "0123456789abcdef";
+    std::string output(64, '0');
+    for (std::size_t index = 0; index < 32; ++index) {
+        output[index * 2] = HEX_DIGITS[(digest[index] >> 4) & 0x0f];
+        output[index * 2 + 1] = HEX_DIGITS[digest[index] & 0x0f];
+    }
+    return output;
+}
+
+inline bool installStreamedArtifact(const Artifact &artifact, int updateCommand,
+                                    String &error) {
+    esp_http_client_config_t config = {};
+    config.url = artifact.url.c_str();
+    config.method = HTTP_METHOD_GET;
+    config.timeout_ms = 60000;
+    config.buffer_size = 4096;
+    config.crt_bundle_attach = FIRMWARE_CRT_BUNDLE_ATTACH;
+
+    esp_http_client_handle_t client = esp_http_client_init(&config);
+    if (client == nullptr) {
+        error = "failed to initialize artifact HTTPS client";
+        return false;
+    }
+    esp_http_client_set_header(client, "Accept-Encoding", "identity");
+
+    bool success = false;
+    if (esp_http_client_open(client, 0) != ESP_OK) {
+        error = "artifact connection failed";
+    } else {
+        const auto contentLength = esp_http_client_fetch_headers(client);
+        const int status = esp_http_client_get_status_code(client);
+        if (status != 200) {
+            error = "artifact returned HTTP " + String(status);
+        } else if (contentLength >= 0 &&
+                   static_cast<std::uint64_t>(contentLength) !=
+                       artifact.sizeBytes) {
+            error = "artifact content length mismatch";
+        } else if (!Update.begin(artifact.sizeBytes, updateCommand)) {
+            error = "update partition rejected artifact";
+        } else {
+            mbedtls_sha256_context sha;
+            mbedtls_sha256_init(&sha);
+            mbedtls_sha256_starts_ret(&sha, 0);
+            std::uint32_t total = 0;
+            unsigned char buffer[4096];
+            int read = 0;
+            bool streamOk = true;
+            while ((read = esp_http_client_read(
+                        client, reinterpret_cast<char *>(buffer),
+                        sizeof(buffer))) > 0) {
+                if (total + read > artifact.sizeBytes ||
+                    Update.write(buffer, read) != static_cast<std::size_t>(read)) {
+                    streamOk = false;
+                    error = "artifact write failed";
+                    break;
+                }
+                mbedtls_sha256_update_ret(&sha, buffer, read);
+                total += read;
+            }
+            unsigned char digest[32] = {};
+            mbedtls_sha256_finish_ret(&sha, digest);
+            mbedtls_sha256_free(&sha);
+
+            if (!streamOk || read < 0 || total != artifact.sizeBytes) {
+                if (error.isEmpty()) error = "artifact download was incomplete";
+                Update.abort();
+            } else if (sha256Hex(digest) != artifact.sha256) {
+                error = "artifact SHA-256 mismatch";
+                Update.abort();
+            } else if (!Update.end(true)) {
+                error = "artifact finalization failed";
+            } else {
+                success = true;
+            }
+        }
+    }
+
+    esp_http_client_close(client);
+    esp_http_client_cleanup(client);
+    return success;
+}
+
+inline bool installApplicationAndFilesystem(const Decision &decision,
+                                            String &error) {
+    bool applicationInstalled = false;
+    for (std::size_t index = 0; index < decision.artifactCount; ++index) {
+        const Artifact &artifact = decision.artifacts[index];
+        if (artifact.role == "filesystem") {
+            if (!installStreamedArtifact(artifact, U_SPIFFS, error)) return false;
+        } else if (artifact.role == "application") {
+            if (!installStreamedArtifact(artifact, U_FLASH, error)) return false;
+            applicationInstalled = true;
+        } else {
+            error = ("unsupported installable artifact role: " + artifact.role).c_str();
+            return false;
+        }
+    }
+    if (!applicationInstalled) {
+        error = "release has no application artifact";
+        return false;
+    }
+    return true;
+}
+
+}  // namespace firmware
+
+#endif

--- a/Software/platformio.ini
+++ b/Software/platformio.ini
@@ -18,11 +18,12 @@ build_unflags =
 build_flags =
     -Wno-error=unknown-pragmas
     -Wno-unknown-pragmas
+    -D FIRMWARE_USE_IDF_CRT_BUNDLE
 lib_deps =
     h2zero/NimBLE-Arduino@2.4.0
     https://github.com/tzapu/WiFiManager.git
     gin66/FastAccelStepper@^0.30.13
-    bblanchon/ArduinoJson
+    bblanchon/ArduinoJson@^7.4.2
     fastled/FastLED@^3.6.0
     olikraus/U8g2@^2.35.8
     ricmoo/QRCode@^0.0.1
@@ -38,6 +39,7 @@ extra_scripts = pre:pre_build_script.py, pre:firmware_build_metadata.py
 [env:development]
 build_flags =
     -D CORE_DEBUG_LEVEL=4
+    -D FIRMWARE_USE_IDF_CRT_BUNDLE
     -Wno-error=unknown-pragmas
     -Wno-unknown-pragmas
     -std=gnu++17
@@ -66,6 +68,7 @@ targets = upload, monitor
 [env:staging]
 build_flags =
     -D CORE_DEBUG_LEVEL=4
+    -D FIRMWARE_USE_IDF_CRT_BUNDLE
     -Wno-error=unknown-pragmas
     -Wno-unknown-pragmas
     -std=gnu++17
@@ -90,6 +93,7 @@ monitor_speed = 115200
 [env:production]
 build_flags =
     -D CORE_DEBUG_LEVEL=2
+    -D FIRMWARE_USE_IDF_CRT_BUNDLE
     -Wno-error=unknown-pragmas
     -Wno-unknown-pragmas
     -std=gnu++17
@@ -120,7 +124,7 @@ targets =
 [env:test]
 lib_deps =
     fabiobatsilva/ArduinoFake@^0.4.0
-    bblanchon/ArduinoJson
+    bblanchon/ArduinoJson@^7.4.2
     olikraus/U8g2@^2.35.8
     ricmoo/QRCode@^0.0.1
 lib_ignore = StrokeEngine

--- a/Software/platformio.ini
+++ b/Software/platformio.ini
@@ -33,7 +33,7 @@ check_skip_packages = true
 check_tool = clangtidy
 check_flags =
     clangtidy: --checks=-\*,bugprone-*,boost-*,modernize-*,performance-*,clang-analyzer-*,cert-dcl03-c,cert-dcl21-cpp,cert-dcl58-cpp,cert-err34-c,cert-err52-cpp,cert-err58-cpp,cert-err60-cpp,cert-flp30-c,cert-msc50-cpp,cert-msc51-cpp,cert-oop54-cpp,cert-str34-c,cppcoreguidelines-interfaces-global-init,cppcoreguidelines-narrowing-conversions,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-pro-type-static-cast-downcast,cppcoreguidelines-slicing,google-default-arguments,google-explicit-constructor,google-runtime-operator,hicpp-exception-baseclass,hicpp-multiway-paths-covered,hicpp-signed-bitwise,portability-simd-intrinsics,readability-avoid-const-params-in-decls,readability-const-return-type,readability-container-size-empty,readability-convert-member-functions-to-static,readability-delete-null-pointer,readability-deleted-default,readability-inconsistent-declaration-parameter-name,readability-make-member-function-const,readability-misleading-indentation,readability-misplaced-array-index,readability-non-const-parameter,readability-redundant-control-flow,readability-redundant-declaration,readability-redundant-function-ptr-dereference,readability-redundant-smartptr-get,readability-simplify-subscript-expr,readability-static-accessed-through-instance,readability-static-definition-in-anonymous-namespace,readability-string-compare,readability-uniqueptr-delete-release,readability-use-anyofallof,-modernize-use-trailing-return-type,-readability-convert-member-functions-to-static,-bugprone-easily-swappable-parameters,-readability-make-member-function-const --fix
-extra_scripts = pre:pre_build_script.py
+extra_scripts = pre:pre_build_script.py, pre:firmware_build_metadata.py
 
 [env:development]
 build_flags =
@@ -70,14 +70,15 @@ build_flags =
     -Wno-unknown-pragmas
     -std=gnu++17
     -D SW_VERSION=0
-    -D RAD_SERVER="\"https://dashboard.researchanddesire.com\""
+    -D FIRMWARE_TRACK="\"staging\""
+    -D RAD_SERVER="\"https://staging.researchanddesire.com\""
     -D MQTT_SERVER="\"mqtts://te9acc16.ala.us-east-1.emqxsl.com\""
     -D MQTT_PORT=8883
-    -D RAD_SERVER_SHORT="\"https://dashboard.researchanddesire.com\""
+    -D RAD_SERVER_SHORT="\"https://staging.researchanddesire.com\""
     -D CONFIG_NIMBLE_CPP_LOG_LEVEL=0
     -D CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE=6144
     -D PRETEND_TO_BE_FLESHY_THRUST_SYNC
-    -D RAD_SERVER="\"https://dashboard.researchanddesire.com\""
+    -D RAD_SERVER="\"https://staging.researchanddesire.com\""
     -D MQTT_USERNAME="\"5k0vjgg9hCwZGAFnmFJg7nTU6sDElr43\""
     -D MQTT_PASSWORD="\"tJDV2u8eGdMBPzHlGKQBnirCrrA9zg5w\""
 extends = common
@@ -85,7 +86,6 @@ platform = espressif32
 board = esp32dev
 framework = arduino, espidf
 monitor_speed = 115200
-targets = upload, monitor
 
 [env:production]
 build_flags =
@@ -94,6 +94,7 @@ build_flags =
     -Wno-unknown-pragmas
     -std=gnu++17
     -D SW_VERSION=0
+    -D FIRMWARE_TRACK="\"main\""
     -D RAD_SERVER="\"https://dashboard.researchanddesire.com\""
     -D MQTT_SERVER="\"mqtts://te9acc16.ala.us-east-1.emqxsl.com\""
     -D MQTT_PORT=8883
@@ -138,7 +139,7 @@ build_flags =
 build_unflags =
     -std=gnu++11
 build_src_filter = +<stub.cpp>
-test_ignore = test_hw_*, test_measurements
+test_ignore = test_hw_*, test_measurements, test_display
 lib_ldf_mode = deep+
 lib_compat_mode = off
 platform = native

--- a/Software/src/constants/Version.h
+++ b/Software/src/constants/Version.h
@@ -1,9 +1,9 @@
 #ifndef OSSM_VERSION_H
 #define OSSM_VERSION_H
 
-#define VERSION "1.0.34"
+#define VERSION "1.0.35"
 #define MAJOR_VERSION 1
 #define MINOR_VERSION 0
-#define PATCH_VERSION 34
+#define PATCH_VERSION 35
 
 #endif  // OSSM_VERSION_H

--- a/Software/src/utils/update.cpp
+++ b/Software/src/utils/update.cpp
@@ -1,156 +1,48 @@
 #include "update.h"
 
 #include <Arduino.h>
-#include <esp_crt_bundle.h>
+#include <WiFi.h>
 #include <esp_heap_caps.h>
-#include <esp_http_client.h>
-#include <esp_https_ota.h>
 #include <esp_log.h>
 #include <esp_system.h>
 
-#include "ArduinoJson.h"
+#include "FirmwareUpdateRuntime.h"
 #include "constants/LogTags.h"
+#include "constants/Version.h"
 #include "ossm/Events.h"
 #include "ossm/pages/update.h"
 #include "ossm/state/state.h"
 #include "services/communication/mqtt.h"
-#include "structs/Version.h"
 
-// NOTE: logs in updateTask are ESP_LOGW so they are visible in the production
-// build (CORE_DEBUG_LEVEL=2 strips ESP_LOGI/D). The free-heap values are the
-// whole point of this pass — we want to see how much room TLS actually has.
+#ifndef FIRMWARE_BUILD_SHA
+#define FIRMWARE_BUILD_SHA "unknown"
+#endif
 
-// Minimal HTTPS GET using the ESP-IDF client with full certificate-bundle
-// validation (never setInsecure — that masks TLS-memory issues in prod).
-// Returns the HTTP status code, or -1 on transport failure; the response body
-// is written to *out when provided.
-static int otaHttpGet(const String &url, String *out, int timeoutMs) {
-    esp_http_client_config_t config = {};
-    config.url = url.c_str();
-    config.timeout_ms = timeoutMs;
-    config.crt_bundle_attach = esp_crt_bundle_attach;
+#ifndef FIRMWARE_TRACK
+#define FIRMWARE_TRACK "main"
+#endif
 
-    esp_http_client_handle_t client = esp_http_client_init(&config);
-    if (client == nullptr) {
-        return -1;
-    }
+namespace {
 
-    int status = -1;
-    if (esp_http_client_open(client, 0) == ESP_OK) {
-        esp_http_client_fetch_headers(client);
-        status = esp_http_client_get_status_code(client);
-
-        if (out != nullptr) {
-            out->clear();
-            char buffer[256];
-            int read = 0;
-            while ((read = esp_http_client_read(client, buffer,
-                                                sizeof(buffer) - 1)) > 0) {
-                buffer[read] = '\0';
-                *out += buffer;
-            }
-        }
-        esp_http_client_close(client);
-    }
-
-    esp_http_client_cleanup(client);
-    return status;
-}
-
-// Fetch the published version for the production channel. Returns currentVersion
-// on any failure (incl. a TLS allocation failure under low heap) so a flaky
-// network never triggers a spurious update or a crash.
-static Version getRemoteVersion() {
-    String url = String(OtaConfig::OTA_BASE_URL) + OtaConfig::PRODUCTION_PATH +
-                 OtaConfig::VERSION_JSON;
-
-    String payload;
-    int status = otaHttpGet(url, &payload, 15000);
-    if (status != 200) {
-        ESP_LOGW(UPDATE_TAG, "Update check failed (HTTP %d)", status);
-        return currentVersion;
-    }
-
-    JsonDocument version;
-    DeserializationError error = deserializeJson(version, payload);
-    if (error) {
-        ESP_LOGW(UPDATE_TAG, "Failed to parse version.json: %s", error.c_str());
-        return currentVersion;
-    }
-
+firmware::DeviceReport makeDeviceReport() {
     return {
-        .major = version["major"] | currentVersion.major,
-        .minor = version["minor"] | currentVersion.minor,
-        .patch = version["patch"] | currentVersion.patch,
+        .deviceType = "ossm",
+        .deviceId = std::string(WiFi.macAddress().c_str()),
+        .reportedTrack = FIRMWARE_TRACK,
+        .currentVersion = VERSION,
+        .currentBuild = FIRMWARE_BUILD_SHA,
+        .firmwareHash = "",
+        .chip = std::string(ESP.getChipModel()),
+        .hardwareRevision = "ossm-v1",
+        .flashSizeBytes = ESP.getFlashChipSize(),
+        .partitionLayout = "ossm-ota-v1",
     };
 }
 
-// Strictly-newer 3-way semver comparison (only updates upward → no downgrades).
-static bool isNewer(const Version &remote) {
-    if (remote.major != currentVersion.major) {
-        return remote.major > currentVersion.major;
+void finishWithoutUpdate(bool mqttStopped, const String &reason) {
+    if (!reason.isEmpty()) {
+        ESP_LOGE(UPDATE_TAG, "Firmware update stopped: %s", reason.c_str());
     }
-    if (remote.minor != currentVersion.minor) {
-        return remote.minor > currentVersion.minor;
-    }
-    return remote.patch > currentVersion.patch;
-}
-
-// The whole update runs here, on its own task with a TLS-sized stack (mirrors
-// pairingTask). On a successful OTA the device reboots; otherwise it posts
-// UpdateUnavailable so the SM shows "no update" and returns to the menu, then
-// self-deletes. BLE is intentionally left up — this pass measures whether TLS
-// fits alongside it. If TLS can't allocate, it fails gracefully (no crash).
-static void updateTask(void *pvParameters) {
-    ESP_LOGW(UPDATE_TAG, "Update task started (free heap: %lu, largest block: %lu)",
-             (unsigned long)esp_get_free_heap_size(),
-             (unsigned long)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
-
-    // Free MQTT's TLS memory and stop its competing reconnect retries for the
-    // duration of the update. On success the reboot brings MQTT back fresh; on
-    // the no-update / failure paths we restart it before returning.
-    bool mqttStopped = false;
-    if (mqttClient != nullptr) {
-        esp_mqtt_client_stop(mqttClient);
-        mqttStopped = true;
-    }
-
-    Version remote = getRemoteVersion();
-    ESP_LOGW(UPDATE_TAG, "Version check done (free heap: %lu)",
-             (unsigned long)esp_get_free_heap_size());
-
-    if (!isNewer(remote)) {
-        ESP_LOGW(UPDATE_TAG, "No newer version available");
-        if (mqttStopped) {
-            esp_mqtt_client_start(mqttClient);
-        }
-        stateMachine->process_event(UpdateUnavailable{});
-        vTaskDelete(nullptr);
-        return;
-    }
-
-    pages::drawUpdating();
-
-    String url = String(OtaConfig::OTA_BASE_URL) + OtaConfig::PRODUCTION_PATH +
-                 OtaConfig::FIRMWARE_BIN;
-    ESP_LOGW(UPDATE_TAG, "Starting OTA from %s (free heap: %lu, largest block: %lu)",
-             url.c_str(), (unsigned long)esp_get_free_heap_size(),
-             (unsigned long)heap_caps_get_largest_free_block(MALLOC_CAP_8BIT));
-
-    esp_http_client_config_t httpConfig = {};
-    httpConfig.url = url.c_str();
-    httpConfig.timeout_ms = 30000;
-    httpConfig.buffer_size = 4096;
-    httpConfig.buffer_size_tx = 1024;
-    httpConfig.crt_bundle_attach = esp_crt_bundle_attach;
-
-    esp_err_t ret = esp_https_ota(&httpConfig);
-    if (ret == ESP_OK) {
-        ESP_LOGW(UPDATE_TAG, "OTA succeeded, restarting...");
-        esp_restart();
-    }
-
-    ESP_LOGE(UPDATE_TAG, "OTA failed: %s", esp_err_to_name(ret));
     if (mqttStopped) {
         esp_mqtt_client_start(mqttClient);
     }
@@ -158,9 +50,58 @@ static void updateTask(void *pvParameters) {
     vTaskDelete(nullptr);
 }
 
-// State-machine action (runs in the button-task context). Only spawns the task
-// — cheap, no TLS — so the button task's small stack is never the one doing the
-// handshake.
+// The complete HTTPS check and install remains isolated from the button task.
+// MQTT is paused so its TLS session cannot compete with the update client for
+// heap; motor control is never invoked by this task.
+void updateTask(void *pvParameters) {
+    ESP_LOGW(UPDATE_TAG,
+             "Update task started: %s %s (%s), heap=%lu, largest=%lu",
+             VERSION, FIRMWARE_BUILD_SHA, FIRMWARE_TRACK,
+             static_cast<unsigned long>(esp_get_free_heap_size()),
+             static_cast<unsigned long>(
+                 heap_caps_get_largest_free_block(MALLOC_CAP_8BIT)));
+
+    bool mqttStopped = false;
+    if (mqttClient != nullptr) {
+        esp_mqtt_client_stop(mqttClient);
+        mqttStopped = true;
+    }
+
+    if (WiFi.status() != WL_CONNECTED) {
+        finishWithoutUpdate(mqttStopped, "Wi-Fi is disconnected");
+        return;
+    }
+
+    firmware::Decision decision;
+    String error;
+    const firmware::DeviceReport report = makeDeviceReport();
+    if (!firmware::postCheck(RAD_SERVER, report, decision, error)) {
+        finishWithoutUpdate(mqttStopped, error);
+        return;
+    }
+
+    ESP_LOGW(UPDATE_TAG,
+             "Resolver assigned track=%s update=%s target=%s next=%s",
+             decision.assignedTrack.c_str(),
+             decision.updateAvailable ? "true" : "false",
+             decision.targetVersion.c_str(), decision.nextHopVersion.c_str());
+    if (!decision.updateAvailable) {
+        finishWithoutUpdate(mqttStopped, "");
+        return;
+    }
+
+    pages::drawUpdating();
+    if (!firmware::installApplicationAndFilesystem(decision, error)) {
+        finishWithoutUpdate(mqttStopped, error);
+        return;
+    }
+
+    ESP_LOGW(UPDATE_TAG, "Verified firmware installed; restarting");
+    esp_restart();
+}
+
+}  // namespace
+
 void ossmStartUpdate() {
     xTaskCreatePinnedToCore(updateTask, "updateTask",
                             20 * configMINIMAL_STACK_SIZE, nullptr, 1, nullptr,

--- a/Software/src/utils/update.h
+++ b/Software/src/utils/update.h
@@ -1,24 +1,7 @@
 #ifndef SOFTWARE_UPDATE_H
 #define SOFTWARE_UPDATE_H
 
-#include <cstdint>
-
-// OTA configuration. Single source of truth shared with the webflasher: the
-// Supabase "production" channel. The device fetches version.json, decides for
-// itself whether a newer build exists, and downloads firmware.bin from the same
-// place over validated HTTPS. To move hosts later (e.g. GitHub Pages), only
-// OTA_BASE_URL changes.
-//
-// The actual check + download run in a dedicated FreeRTOS task (see
-// ossmStartUpdate in update.cpp), because a TLS handshake needs far more stack
-// than the button task — where the state machine runs — has available.
-namespace OtaConfig {
-static const char *OTA_BASE_URL =
-    "https://acjajruwevyyatztbkdf.supabase.co/storage/v1/object/public/"
-    "ossm-firmware/";
-static const char *PRODUCTION_PATH = "production/";
-static const char *VERSION_JSON = "version.json";
-static const char *FIRMWARE_BIN = "firmware.bin";
-}  // namespace OtaConfig
+// Starts the database-resolved firmware check in its dedicated TLS task.
+void ossmStartUpdate();
 
 #endif  // SOFTWARE_UPDATE_H

--- a/Software/test/test_firmware_update_protocol/test_main.cpp
+++ b/Software/test/test_firmware_update_protocol/test_main.cpp
@@ -1,0 +1,107 @@
+#include <unity.h>
+
+#include "FirmwareUpdateProtocol.h"
+
+namespace {
+
+const char *VALID_RESPONSE = R"json({
+  "updateAvailable": true,
+  "reportedTrack": "main",
+  "assignedTrack": "staging",
+  "trackChanged": true,
+  "currentVersion": "1.0.34",
+  "targetVersion": "1.0.35",
+  "nextHopVersion": "1.0.35",
+  "update": {
+    "releaseId": "00000000-0000-4000-8000-000000000001",
+    "kind": "firmware",
+    "publishedAt": "2026-07-16T00:00:00.000Z",
+    "artifacts": [
+      {
+        "role": "application",
+        "url": "https://example.supabase.co/storage/v1/object/public/ossm-firmware/releases/1.0.35/0123456789abcdef/firmware.bin",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "sizeBytes": 1024,
+        "installOrder": 1
+      }
+    ]
+  },
+  "nextCheckSeconds": 60
+})json";
+
+void test_serializes_required_and_hardware_fields() {
+    firmware::DeviceReport report{
+        .deviceType = "ossm",
+        .deviceId = "trainer-test-id",
+        .reportedTrack = "main",
+        .currentVersion = "1.0.34",
+        .currentBuild = "0123456789abcdef",
+        .chip = "esp32",
+        .flashSizeBytes = 4194304,
+        .partitionLayout = "legacy-v1",
+    };
+    JsonDocument parsed;
+    deserializeJson(parsed, firmware::serializeReport(report));
+    TEST_ASSERT_EQUAL_STRING("ossm", parsed["deviceType"]);
+    TEST_ASSERT_EQUAL_STRING("main", parsed["reportedTrack"]);
+    TEST_ASSERT_EQUAL_UINT32(4194304, parsed["flashSizeBytes"]);
+    TEST_ASSERT_EQUAL_STRING("legacy-v1", parsed["partitionLayout"]);
+}
+
+void test_parses_cross_track_update_and_orders_artifacts() {
+    firmware::Decision decision;
+    std::string error;
+    TEST_ASSERT_TRUE(
+        firmware::parseDecision(VALID_RESPONSE, "ossm", decision, error));
+    TEST_ASSERT_TRUE(decision.updateAvailable);
+    TEST_ASSERT_EQUAL_STRING("staging", decision.assignedTrack.c_str());
+    TEST_ASSERT_TRUE(decision.trackChanged);
+    TEST_ASSERT_EQUAL_STRING("1.0.35", decision.nextHopVersion.c_str());
+    TEST_ASSERT_EQUAL_UINT32(1, decision.artifactCount);
+    TEST_ASSERT_EQUAL_STRING("application", decision.artifacts[0].role.c_str());
+}
+
+void test_rejects_wrong_bucket_and_non_https_urls() {
+    std::string payload = VALID_RESPONSE;
+    const auto bucket = payload.find("ossm-firmware");
+    payload.replace(bucket, std::string("ossm-firmware").size(), "lkbx-firmware");
+    firmware::Decision decision;
+    std::string error;
+    TEST_ASSERT_FALSE(
+        firmware::parseDecision(payload, "ossm", decision, error));
+
+    payload = VALID_RESPONSE;
+    const auto scheme = payload.find("https://");
+    payload.replace(scheme, std::string("https://").size(), "http://");
+    TEST_ASSERT_FALSE(
+        firmware::parseDecision(payload, "ossm", decision, error));
+
+    payload = VALID_RESPONSE;
+    const auto trustedHost = payload.find("example.supabase.co");
+    payload.replace(trustedHost, std::string("example.supabase.co").size(),
+                    "evil.example");
+    TEST_ASSERT_FALSE(
+        firmware::parseDecision(payload, "ossm", decision, error));
+}
+
+void test_rejects_bad_hash_duplicate_order_and_missing_fields() {
+    std::string payload = VALID_RESPONSE;
+    const auto hash = payload.find(std::string(64, 'a'));
+    payload.replace(hash, 64, "bad");
+    firmware::Decision decision;
+    std::string error;
+    TEST_ASSERT_FALSE(
+        firmware::parseDecision(payload, "ossm", decision, error));
+    TEST_ASSERT_FALSE(firmware::parseDecision("{}", "ossm", decision, error));
+}
+
+}  // namespace
+
+int main(int, char **) {
+    UNITY_BEGIN();
+    RUN_TEST(test_serializes_required_and_hardware_fields);
+    RUN_TEST(test_parses_cross_track_update_and_orders_artifacts);
+    RUN_TEST(test_rejects_wrong_bucket_and_non_https_urls);
+    RUN_TEST(test_rejects_bad_hash_duplicate_order_and_missing_fields);
+    return UNITY_END();
+}

--- a/scripts/prepare_version.py
+++ b/scripts/prepare_version.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Prepare a reviewed semantic-version PR without building release artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+
+
+def bump_version(current: str, bump: str) -> str:
+    major, minor, patch = (int(part) for part in current.split("."))
+    if bump == "major":
+        major, minor, patch = major + 1, 0, 0
+    elif bump == "minor":
+        minor, patch = minor + 1, 0
+    else:
+        patch += 1
+    return f"{major}.{minor}.{patch}"
+
+
+def prepare(header: Path, changelog: Path, bump: str, version_json: Path | None) -> str:
+    content = header.read_text()
+    match = re.search(r'^#define VERSION "(\d+\.\d+\.\d+)"$', content, re.M)
+    if not match:
+        raise ValueError(f"unable to read semantic version from {header}")
+    version = bump_version(match.group(1), bump)
+    major, minor, patch = version.split(".")
+    content = re.sub(r'^#define VERSION ".*"$', f'#define VERSION "{version}"', content, flags=re.M)
+    content = re.sub(r'^#define MAJOR_VERSION \d+$', f'#define MAJOR_VERSION {major}', content, flags=re.M)
+    content = re.sub(r'^#define MINOR_VERSION \d+$', f'#define MINOR_VERSION {minor}', content, flags=re.M)
+    content = re.sub(r'^#define PATCH_VERSION \d+$', f'#define PATCH_VERSION {patch}', content, flags=re.M)
+    header.write_text(content)
+    if version_json:
+        version_json.write_text(json.dumps({"version": version, "major": int(major), "minor": int(minor), "patch": int(patch)}, indent=2) + "\n")
+    notes = changelog.read_text()
+    marker = re.search(r'<Update[^>]*>\n', notes)
+    if not marker:
+        raise ValueError(f"unable to find first Update block in {changelog}")
+    if f"### v{version}" not in notes:
+        draft = f'\n### v{version}\n\n- **Release notes draft** — Replace this line with reviewed release notes before promotion.\n'
+        notes = notes[: marker.end()] + draft + notes[marker.end() :]
+        changelog.write_text(notes)
+    return version
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--header", required=True, type=Path)
+    parser.add_argument("--changelog", required=True, type=Path)
+    parser.add_argument("--bump", required=True, choices=("patch", "minor", "major"))
+    parser.add_argument("--version-json", type=Path)
+    args = parser.parse_args()
+    version = prepare(args.header, args.changelog, args.bump, args.version_json)
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as handle:
+            handle.write(f"version={version}\n")
+    print(version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.0.34",
+  "version": "1.0.35",
   "major": 1,
   "minor": 0,
-  "patch": 34
+  "patch": 35
 }


### PR DESCRIPTION
Implements validation-gated immutable publishing for main and staging.

- builds the branch-mapped PlatformIO environment and embeds track plus commit identity
- obtains short-lived signed upload URLs without exposing Supabase service-role keys
- uploads, downloads, and verifies every object before release registration
- leaves candidates validating until persisted hardware validation succeeds
- adds unit-tested branch mapping and idempotent production tag handling
- converts version preparation and legacy aliases to explicit manual workflows
- removes pull-request mutation of shared firmware storage
- Keeps the existing updater task model while separating staging and production build metadata.

Verified with native tests, publisher tests, workflow linting, and staging plus production firmware builds. No changes are merged to main by this PR.