### PR TITLE
HOTFIX: standardize PR flow and protections

### DIFF
--- a/.cursor/rules/branch-workflow.mdc
+++ b/.cursor/rules/branch-workflow.mdc
@@ -1,0 +1,14 @@
+---
+alwaysApply: true
+description: Required branch, pull request, and merge workflow
+---
+
+# Branch and pull request workflow
+
+- Fetch `origin` before branching.
+- Feature and release work starts from `origin/staging` and opens a pull request into `staging`.
+- Urgent hotfix work starts from `origin/main` and opens a pull request into `main`. The first word of the PR title must be the standalone word `hotfix`, case-insensitively.
+- Normal production promotion is a same-repository `staging` to `main` pull request.
+- After a hotfix lands in `main`, immediately open or update a `main` to `staging` synchronization pull request.
+- Squash feature and hotfix PRs into one focused commit with a concise, imperative title.
+- Merge `staging` to `main` and `main` to `staging` synchronization PRs with merge commits. Never squash or rebase long-lived branch synchronization PRs.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /Documentation
+    target-branch: staging
+    schedule:
+      interval: weekly

--- a/.github/workflows/hotfix-sync.yml
+++ b/.github/workflows/hotfix-sync.yml
@@ -1,0 +1,65 @@
+name: Hotfix sync
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  open-sync-pr:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Identify a direct hotfix
+        id: policy
+        env:
+          BASE_REPOSITORY: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        shell: bash
+        run: |
+          if [[ "$HEAD_REPOSITORY" == "$BASE_REPOSITORY" && "$HEAD_BRANCH" == "staging" ]]; then
+            echo "sync=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          shopt -s nocasematch
+          if [[ "$PR_TITLE" =~ ^hotfix([[:space:][:punct:]]|$) ]]; then
+            echo "sync=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "sync=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update main-to-staging synchronization
+        if: steps.policy.outputs.sync == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.HOTFIX_SYNC_TOKEN }}
+        shell: bash
+        run: |
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error::HOTFIX_SYNC_TOKEN is not configured."
+            exit 1
+          fi
+
+          ahead_by="$(gh api "repos/${GITHUB_REPOSITORY}/compare/staging...main" --jq '.ahead_by')"
+          if [[ "$ahead_by" == "0" ]]; then
+            echo "staging already contains main."
+            exit 0
+          fi
+
+          existing="$(gh pr list --repo "$GITHUB_REPOSITORY" --base staging --head main --state open --json url --jq '.[0].url')"
+          if [[ -n "$existing" ]]; then
+            echo "Synchronization PR already open: $existing"
+            exit 0
+          fi
+
+          gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --base staging \
+            --head main \
+            --title "Sync main hotfixes back to staging" \
+            --body "Carries production hotfix commits back into staging. Merge this PR with a merge commit after all required checks pass; do not squash or rebase it."

--- a/.github/workflows/pr-target-policy.yml
+++ b/.github/workflows/pr-target-policy.yml
@@ -1,0 +1,35 @@
+name: PR target policy
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions: {}
+
+jobs:
+  validate-target:
+    name: PR target policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate source branch or hotfix title
+        env:
+          BASE_REPOSITORY: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        shell: bash
+        run: |
+          if [[ "$HEAD_REPOSITORY" == "$BASE_REPOSITORY" && "$HEAD_BRANCH" == "staging" ]]; then
+            echo "Same-repository staging promotion accepted."
+            exit 0
+          fi
+
+          shopt -s nocasematch
+          if [[ "$PR_TITLE" =~ ^hotfix([[:space:][:punct:]]|$) ]]; then
+            echo "Hotfix title accepted."
+            exit 0
+          fi
+
+          echo "::error::PRs into main must come from this repository's staging branch or begin with the standalone word 'hotfix'. Retarget feature work to staging, or rename a legitimate hotfix."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,11 @@
 ## Branch and Release Policy
 
 - Persistent branches are lowercase `staging` and `main`.
-- Start feature and release work from `staging` and merge it into `staging` first.
-- Promote normal releases with a `staging` to `main` pull request only after every required build, unit, integration, artifact-verification, and OSSM hardware validation succeeds.
-- Only urgent production bug fixes may target `main` directly. Merge each main hotfix back into `staging` immediately.
+- Fetch before branching. Start feature and release work from `origin/staging`, then open the pull request back into `staging`.
+- Only urgent production bug fixes may target `main` directly. Start them from `origin/main`, open the pull request into `main`, and make the standalone word `hotfix` the first word of the PR title (case-insensitive).
+- Promote normal releases with a same-repository `staging` to `main` pull request only after every required build, unit, integration, artifact-verification, and OSSM hardware validation succeeds.
+- Immediately merge every main hotfix back into `staging` with a `main` to `staging` pull request.
+- Squash feature and hotfix pull requests into one focused commit with a concise, imperative title. Merge long-lived branch synchronization pull requests (`staging` to `main` and `main` to `staging`) with a merge commit; never squash or rebase them.
 - Use matching branch names and linked pull requests for changes spanning RAD App or another firmware repository.
 - Staging firmware reports the `staging` track and checks `https://staging.researchanddesire.com`. Main firmware reports `main` and checks `https://dashboard.researchanddesire.com`.
 - Firmware is update-eligible only after its immutable Supabase artifacts and all required validation records verify. Missing hardware runners leave a release in `validating`; never bypass a gate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,17 +66,18 @@ smooth as possible.
 
 ## 🌳 Branching & Pull Requests
 
-- **Branching:**
-  - Follow the
-    [Git Branching Strategy](Software/docs/Git%20Branching%20Strategy) if
-    contributing regularly.
-  - For small fixes, branch from `main` or the latest development branch.
-- **Pull Requests:**
-  1. Ensure your branch is up to date with the latest `main`.
-  2. Run all tests and ensure they pass.
-  3. Open a pull request with a clear description of your changes and reference
-     any related issues.
-  4. Be responsive to code review feedback.
+- Fetch `origin`, branch feature work from `origin/staging`, and open the pull
+  request back into `staging`.
+- Reserve direct production hotfixes for branches created from `origin/main`.
+  Open those pull requests into `main` and begin the PR title with the standalone
+  word `hotfix` (case-insensitive).
+- Run the relevant tests and reference related issues in the PR description.
+- Keep commits focused. Feature and hotfix PRs are squash-merged into one commit
+  with a concise, imperative title.
+- Promotions from `staging` to `main` and hotfix synchronization from `main` to
+  `staging` use merge commits so the long-lived branches retain shared ancestry;
+  never squash or rebase these synchronization PRs.
+- Be responsive to code review feedback.
 
 ## 🛟 Getting Help
 


### PR DESCRIPTION
## What changed

- adds the required main-target policy and hotfix synchronization workflows
- standardizes feature, hotfix, promotion, and backmerge guidance for contributors and agents
- standardizes squash merging for topic PRs and merge commits for long-lived branch synchronization

## Why

Feature work should flow through staging, while only explicitly titled production hotfixes may target main directly. Hotfixes must then be synchronized back to staging without losing shared branch ancestry.

## Validation

- workflow YAML parsed successfully
- new workflows passed actionlint
- title matching accepts `HOTFIX:`, `Hotfix -`, and `hotfix ` while rejecting `hotfixing` and titles where hotfix is not the first word
