### PR TITLE
Prevent repeated firmware update loops

### DIFF
--- a/.github/scripts/download_verified_release.py
+++ b/.github/scripts/download_verified_release.py
@@ -17,6 +17,26 @@ CONTROL_PLANE = "https://dashboard.researchanddesire.com"
 REQUIRED_GATES = {"build", "unit", "integration", "artifact", "hardware"}
 
 
+def legacy_version_document(
+    version: str, build_sha: str, release_id: str
+) -> dict[str, Any]:
+    """Build the metadata shape consumed by every legacy OSSM updater."""
+    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", version)
+    if match is None:
+        raise RuntimeError(
+            f"release version is not numeric semantic version: {version}"
+        )
+    major, minor, patch = (int(part) for part in match.groups())
+    return {
+        "version": version,
+        "major": major,
+        "minor": minor,
+        "patch": patch,
+        "buildSha": build_sha,
+        "releaseId": release_id,
+    }
+
+
 def fetch(url: str, token: str | None = None) -> bytes:
     headers = {"User-Agent": "rad-firmware-alias/1"}
     if token:
@@ -67,7 +87,13 @@ def download_release(release_id: str, track: str, device: str, output: Path) -> 
         if hashlib.sha256(content).hexdigest() != artifact.get("sha256"):
             raise RuntimeError(f"SHA-256 mismatch for {filename}")
         (output / filename).write_bytes(content)
-    (output / "version.json").write_text(json.dumps({"version": status["version"], "buildSha": build_sha, "releaseId": release_id}, indent=2) + "\n")
+    (output / "version.json").write_text(
+        json.dumps(
+            legacy_version_document(status["version"], build_sha, release_id),
+            indent=2,
+        )
+        + "\n"
+    )
     return status["version"]
 
 

--- a/.github/scripts/test_download_verified_release.py
+++ b/.github/scripts/test_download_verified_release.py
@@ -1,0 +1,29 @@
+import unittest
+
+from download_verified_release import legacy_version_document
+
+
+class LegacyVersionDocumentTests(unittest.TestCase):
+    def test_includes_fields_required_by_legacy_updaters(self):
+        document = legacy_version_document("1.2.34", "a" * 40, "release-id")
+
+        self.assertEqual(
+            document,
+            {
+                "version": "1.2.34",
+                "major": 1,
+                "minor": 2,
+                "patch": 34,
+                "buildSha": "a" * 40,
+                "releaseId": "release-id",
+            },
+        )
+
+    def test_rejects_non_numeric_semantic_version(self):
+        for version in ("1.2", "v1.2.3", "1.2.3-beta"):
+            with self.subTest(version=version), self.assertRaises(RuntimeError):
+                legacy_version_document(version, "a" * 40, "release-id")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/publish_firmware.yml
+++ b/.github/workflows/publish_firmware.yml
@@ -7,6 +7,8 @@ on:
       - "Software/**"
       - "scripts/release_version.py"
       - "scripts/test_release_version.py"
+      - ".github/scripts/download_verified_release.py"
+      - ".github/scripts/test_download_verified_release.py"
       - ".github/scripts/publish_immutable_firmware.py"
       - ".github/scripts/test_publish_immutable_firmware.py"
       - ".github/scripts/release_workflow.py"
@@ -133,6 +135,7 @@ jobs:
 
       - name: Test publisher
         run: |
+          python .github/scripts/test_download_verified_release.py
           python .github/scripts/test_publish_immutable_firmware.py
           python .github/scripts/test_release_workflow.py
 

--- a/.github/workflows/pull_request_action.yml
+++ b/.github/workflows/pull_request_action.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Test immutable publisher
         run: |
+          python .github/scripts/test_download_verified_release.py
           python .github/scripts/test_publish_immutable_firmware.py
           python .github/scripts/test_release_workflow.py
 

--- a/Software/lib/FirmwareUpdateProtocol/src/FirmwareUpdateProtocol.h
+++ b/Software/lib/FirmwareUpdateProtocol/src/FirmwareUpdateProtocol.h
@@ -14,6 +14,7 @@ constexpr int PROTOCOL_VERSION = 1;
 constexpr std::size_t MAX_ARTIFACTS = 8;
 
 struct DeviceReport {
+    int protocolVersion = PROTOCOL_VERSION;
     std::string deviceType;
     std::string deviceId;
     std::string reportedTrack;
@@ -21,8 +22,12 @@ struct DeviceReport {
     std::string currentBuild;
     std::string firmwareHash;
     std::string chip;
+    std::uint32_t chipRevision = 0;
+    std::uint32_t chipCores = 0;
     std::string hardwareRevision;
     std::uint32_t flashSizeBytes = 0;
+    std::uint32_t psramSizeBytes = 0;
+    std::uint32_t otaSlotSizeBytes = 0;
     std::string partitionLayout;
 };
 
@@ -35,7 +40,9 @@ struct Artifact {
 };
 
 struct Decision {
-    bool updateAvailable = false;
+    int protocolVersion = PROTOCOL_VERSION;
+    bool shouldUpdate = false;
+    std::string reason;
     std::string reportedTrack;
     std::string assignedTrack;
     bool trackChanged = false;
@@ -43,6 +50,7 @@ struct Decision {
     std::string targetVersion;
     std::string nextHopVersion;
     std::string releaseId;
+    std::string buildSha;
     std::string kind;
     std::array<Artifact, MAX_ARTIFACTS> artifacts{};
     std::size_t artifactCount = 0;
@@ -78,6 +86,34 @@ inline bool isSha256(const std::string &value) {
            });
 }
 
+inline bool isBuildSha(const std::string &value) {
+    return value.size() >= 7 && value.size() <= 64 &&
+           std::all_of(value.begin(), value.end(), [](const char character) {
+               return std::isxdigit(static_cast<unsigned char>(character));
+           });
+}
+
+inline bool isDecisionReason(const std::string &value) {
+    return value == "update-available" || value == "already-current" ||
+           value == "no-target" || value == "updates-disabled" ||
+           value == "release-paused" || value == "rollout-denied" ||
+           value == "incompatible-device";
+}
+
+// Repository build IDs may be reported as either full or abbreviated Git SHAs.
+// Treat either prefix as the same build and compare without case sensitivity.
+inline bool isSameBuild(const std::string &left, const std::string &right) {
+    if (!isBuildSha(left) || !isBuildSha(right)) return false;
+    const std::size_t length = std::min(left.size(), right.size());
+    for (std::size_t index = 0; index < length; ++index) {
+        if (std::tolower(static_cast<unsigned char>(left[index])) !=
+            std::tolower(static_cast<unsigned char>(right[index]))) {
+            return false;
+        }
+    }
+    return true;
+}
+
 inline bool isArtifactRole(const std::string &role) {
     return role == "application" || role == "filesystem" ||
            role == "bootloader" || role == "partitions" ||
@@ -109,6 +145,7 @@ inline bool isHttpsArtifactUrl(const std::string &url,
 
 inline std::string serializeReport(const DeviceReport &report) {
     JsonDocument document;
+    document["protocolVersion"] = report.protocolVersion;
     document["deviceType"] = report.deviceType;
     document["deviceId"] = report.deviceId;
     document["reportedTrack"] = report.reportedTrack;
@@ -118,10 +155,15 @@ inline std::string serializeReport(const DeviceReport &report) {
     if (!report.firmwareHash.empty())
         document["firmwareHash"] = report.firmwareHash;
     if (!report.chip.empty()) document["chip"] = report.chip;
+    document["chipRevision"] = report.chipRevision;
+    if (report.chipCores > 0) document["chipCores"] = report.chipCores;
     if (!report.hardwareRevision.empty())
         document["hardwareRevision"] = report.hardwareRevision;
     if (report.flashSizeBytes > 0)
         document["flashSizeBytes"] = report.flashSizeBytes;
+    document["psramSizeBytes"] = report.psramSizeBytes;
+    if (report.otaSlotSizeBytes > 0)
+        document["otaSlotSizeBytes"] = report.otaSlotSizeBytes;
     if (!report.partitionLayout.empty())
         document["partitionLayout"] = report.partitionLayout;
     std::string output;
@@ -154,8 +196,42 @@ inline bool parseDecision(const std::string &payload,
     }
 
     Decision parsed;
-    if (!document["updateAvailable"].is<bool>() ||
-        !document["trackChanged"].is<bool>() ||
+    const JsonVariantConst protocolVersion = document["protocolVersion"];
+    if (!protocolVersion.isNull()) {
+        if (!protocolVersion.is<int>() ||
+            protocolVersion.as<int>() != PROTOCOL_VERSION) {
+            error = "unsupported protocol version";
+            return false;
+        }
+        parsed.protocolVersion = protocolVersion.as<int>();
+    }
+
+    const bool hasShouldUpdate = document["shouldUpdate"].is<bool>();
+    const bool hasUpdateAvailable = document["updateAvailable"].is<bool>();
+    if ((!hasShouldUpdate && !hasUpdateAvailable) ||
+        (hasShouldUpdate && hasUpdateAvailable &&
+         document["shouldUpdate"].as<bool>() !=
+             document["updateAvailable"].as<bool>())) {
+        error = "missing or conflicting update decision";
+        return false;
+    }
+    parsed.shouldUpdate = hasShouldUpdate
+                              ? document["shouldUpdate"].as<bool>()
+                              : document["updateAvailable"].as<bool>();
+
+    const JsonVariantConst reason = document["reason"];
+    const bool canonicalResponse = !protocolVersion.isNull() ||
+                                   hasShouldUpdate || !reason.isNull();
+    if (canonicalResponse) {
+        if (!hasShouldUpdate || !readRequiredString(reason, parsed.reason) ||
+            !isDecisionReason(parsed.reason) ||
+            parsed.shouldUpdate != (parsed.reason == "update-available")) {
+            error = "invalid canonical update reason";
+            return false;
+        }
+    }
+
+    if (!document["trackChanged"].is<bool>() ||
         !document["nextCheckSeconds"].is<std::uint32_t>() ||
         !readRequiredString(document["reportedTrack"], parsed.reportedTrack) ||
         !readRequiredString(document["assignedTrack"], parsed.assignedTrack) ||
@@ -168,10 +244,9 @@ inline bool parseDecision(const std::string &payload,
         return false;
     }
 
-    parsed.updateAvailable = document["updateAvailable"].as<bool>();
     parsed.trackChanged = document["trackChanged"].as<bool>();
     parsed.nextCheckSeconds = document["nextCheckSeconds"].as<std::uint32_t>();
-    if (!parsed.updateAvailable) {
+    if (!parsed.shouldUpdate) {
         if (!document["update"].isNull()) {
             error = "no-update response contains update data";
             return false;
@@ -189,6 +264,17 @@ inline bool parseDecision(const std::string &payload,
         (parsed.kind != "firmware" && parsed.kind != "migration") ||
         parsed.nextHopVersion.empty()) {
         error = "invalid update metadata";
+        return false;
+    }
+
+    if (!update["buildSha"].isNull()) {
+        if (!readRequiredString(update["buildSha"], parsed.buildSha) ||
+            !isBuildSha(parsed.buildSha)) {
+            error = "invalid update build SHA";
+            return false;
+        }
+    } else if (canonicalResponse) {
+        error = "canonical update response is missing build SHA";
         return false;
     }
 
@@ -224,6 +310,33 @@ inline bool parseDecision(const std::string &payload,
                   return left.installOrder < right.installOrder;
               });
     decision = parsed;
+    return true;
+}
+
+inline bool validateDecisionForReport(const DeviceReport &report,
+                                      const Decision &decision,
+                                      std::string &error) {
+    if (decision.reportedTrack != report.reportedTrack ||
+        decision.currentVersion != report.currentVersion ||
+        decision.trackChanged !=
+            (decision.reportedTrack != decision.assignedTrack)) {
+        error = "firmware response does not match device report";
+        return false;
+    }
+    if (decision.shouldUpdate &&
+        decision.assignedTrack == report.reportedTrack) {
+        if (isSameBuild(report.currentBuild, decision.buildSha)) {
+            error = "firmware response selected the running build";
+            return false;
+        }
+        // Legacy responses do not identify the build. On the same track, a
+        // same-version offer cannot be distinguished from the running image.
+        if (decision.buildSha.empty() &&
+            decision.nextHopVersion == report.currentVersion) {
+            error = "firmware response selected the running version";
+            return false;
+        }
+    }
     return true;
 }
 

--- a/Software/lib/FirmwareUpdateProtocol/src/FirmwareUpdateRuntime.h
+++ b/Software/lib/FirmwareUpdateProtocol/src/FirmwareUpdateRuntime.h
@@ -72,13 +72,12 @@ inline bool postCheck(const char *apiBaseUrl, const DeviceReport &report,
 
     esp_http_client_close(client);
     esp_http_client_cleanup(client);
-    if (success &&
-        (decision.reportedTrack != report.reportedTrack ||
-         decision.currentVersion != report.currentVersion ||
-         decision.trackChanged !=
-             (decision.reportedTrack != decision.assignedTrack))) {
-        error = "firmware response does not match device report";
-        return false;
+    if (success) {
+        std::string validationError;
+        if (!validateDecisionForReport(report, decision, validationError)) {
+            error = validationError.c_str();
+            return false;
+        }
     }
     return success;
 }

--- a/Software/src/main.cpp
+++ b/Software/src/main.cpp
@@ -13,6 +13,7 @@
 #include "services/led.h"
 #include "services/stepper.h"
 #include "services/wm.h"
+#include "utils/update.h"
 
 namespace sml = boost::sml;
 using namespace sml;
@@ -36,6 +37,12 @@ using namespace sml;
 
 OneButton button(Pins::Remote::encoderSwitch, false);
 
+#ifdef CONFIG_APP_ROLLBACK_ENABLE
+// Keep Arduino core startup from accepting a pending image before OSSM has
+// initialized enough of the application to confirm it explicitly.
+extern "C" bool verifyRollbackLater() { return true; }
+#endif
+
 void __attribute__((weak)) setup() {
     // Suppress verbose GPIO configuration logs
     esp_log_level_set("gpio", ESP_LOG_WARN);
@@ -56,6 +63,10 @@ void __attribute__((weak)) setup() {
 
     // Initialize state machine after global state is set up
     initStateMachine();
+
+    // The board, display, and state machine initialized successfully. Confirm
+    // the running image if a rollback-capable bootloader marked it pending.
+    ossmConfirmRunningImage();
 
     // ialize LED for BLE and machine status indication
     ESP_LOGI("MAIN", "LED initialized for BLE and machine status indication");

--- a/Software/src/utils/update.cpp
+++ b/Software/src/utils/update.cpp
@@ -3,7 +3,10 @@
 #include <Arduino.h>
 #include <WiFi.h>
 #include <esp_heap_caps.h>
+#include <esp_flash.h>
 #include <esp_log.h>
+#include <esp_ota_ops.h>
+#include <esp_partition.h>
 #include <esp_system.h>
 
 #include "FirmwareUpdateRuntime.h"
@@ -24,19 +27,46 @@
 
 namespace {
 
+std::uint32_t physicalFlashSizeBytes() {
+    std::uint32_t size = 0;
+    if (esp_flash_get_physical_size(nullptr, &size) == ESP_OK && size > 0) {
+        return size;
+    }
+    return ESP.getFlashChipSize();
+}
+
+std::uint32_t otaSlotSizeBytes() {
+    const esp_partition_t *partition =
+        esp_ota_get_next_update_partition(nullptr);
+    return partition == nullptr ? 0 : partition->size;
+}
+
+std::string runningFirmwareHash() {
+    const esp_partition_t *running = esp_ota_get_running_partition();
+    unsigned char digest[32] = {};
+    if (running == nullptr || esp_partition_get_sha256(running, digest) != ESP_OK) {
+        return "";
+    }
+    return firmware::sha256Hex(digest);
+}
+
 firmware::DeviceReport makeDeviceReport() {
-    return {
-        .deviceType = "ossm",
-        .deviceId = std::string(WiFi.macAddress().c_str()),
-        .reportedTrack = FIRMWARE_TRACK,
-        .currentVersion = VERSION,
-        .currentBuild = FIRMWARE_BUILD_SHA,
-        .firmwareHash = "",
-        .chip = std::string(ESP.getChipModel()),
-        .hardwareRevision = "ossm-v1",
-        .flashSizeBytes = ESP.getFlashChipSize(),
-        .partitionLayout = "ossm-ota-v1",
-    };
+    firmware::DeviceReport report;
+    report.deviceType = "ossm";
+    report.deviceId = std::string(WiFi.macAddress().c_str());
+    report.reportedTrack = FIRMWARE_TRACK;
+    report.currentVersion = VERSION;
+    report.currentBuild = FIRMWARE_BUILD_SHA;
+    report.firmwareHash = runningFirmwareHash();
+    report.chip = std::string(ESP.getChipModel());
+    report.chipRevision = ESP.getChipRevision();
+    report.chipCores = ESP.getChipCores();
+    report.hardwareRevision = "ossm-v1";
+    report.flashSizeBytes = physicalFlashSizeBytes();
+    report.psramSizeBytes = ESP.getPsramSize();
+    report.otaSlotSizeBytes = otaSlotSizeBytes();
+    report.partitionLayout = "ossm-ota-v1";
+    return report;
 }
 
 void finishWithoutUpdate(bool mqttStopped, const String &reason) {
@@ -81,11 +111,12 @@ void updateTask(void *pvParameters) {
     }
 
     ESP_LOGW(UPDATE_TAG,
-             "Resolver assigned track=%s update=%s target=%s next=%s",
+             "Resolver assigned track=%s shouldUpdate=%s target=%s next=%s reason=%s",
              decision.assignedTrack.c_str(),
-             decision.updateAvailable ? "true" : "false",
-             decision.targetVersion.c_str(), decision.nextHopVersion.c_str());
-    if (!decision.updateAvailable) {
+             decision.shouldUpdate ? "true" : "false",
+             decision.targetVersion.c_str(), decision.nextHopVersion.c_str(),
+             decision.reason.c_str());
+    if (!decision.shouldUpdate) {
         finishWithoutUpdate(mqttStopped, "");
         return;
     }
@@ -101,6 +132,24 @@ void updateTask(void *pvParameters) {
 }
 
 }  // namespace
+
+void ossmConfirmRunningImage() {
+    const esp_partition_t *running = esp_ota_get_running_partition();
+    esp_ota_img_states_t state;
+    if (running == nullptr ||
+        esp_ota_get_state_partition(running, &state) != ESP_OK ||
+        state != ESP_OTA_IMG_PENDING_VERIFY) {
+        return;
+    }
+
+    const esp_err_t result = esp_ota_mark_app_valid_cancel_rollback();
+    if (result == ESP_OK) {
+        ESP_LOGW(UPDATE_TAG, "Confirmed pending OTA application");
+    } else {
+        ESP_LOGE(UPDATE_TAG, "Failed to confirm pending OTA application: %s",
+                 esp_err_to_name(result));
+    }
+}
 
 void ossmStartUpdate() {
     xTaskCreatePinnedToCore(updateTask, "updateTask",

--- a/Software/src/utils/update.h
+++ b/Software/src/utils/update.h
@@ -4,4 +4,8 @@
 // Starts the database-resolved firmware check in its dedicated TLS task.
 void ossmStartUpdate();
 
+// Confirms a newly booted OTA image only when ESP-IDF reports it as pending
+// verification. This is a no-op on existing rollback-disabled bootloaders.
+void ossmConfirmRunningImage();
+
 #endif  // SOFTWARE_UPDATE_H

--- a/Software/test/test_firmware_update_protocol/test_main.cpp
+++ b/Software/test/test_firmware_update_protocol/test_main.cpp
@@ -1,11 +1,16 @@
 #include <unity.h>
 
+#include <functional>
+
 #include "FirmwareUpdateProtocol.h"
 
 namespace {
 
 const char *VALID_RESPONSE = R"json({
+  "protocolVersion": 1,
+  "shouldUpdate": true,
   "updateAvailable": true,
+  "reason": "update-available",
   "reportedTrack": "main",
   "assignedTrack": "staging",
   "trackChanged": true,
@@ -14,6 +19,7 @@ const char *VALID_RESPONSE = R"json({
   "nextHopVersion": "1.0.35",
   "update": {
     "releaseId": "00000000-0000-4000-8000-000000000001",
+    "buildSha": "0123456789abcdef0123456789abcdef01234567",
     "kind": "firmware",
     "publishedAt": "2026-07-16T00:00:00.000Z",
     "artifacts": [
@@ -29,36 +35,191 @@ const char *VALID_RESPONSE = R"json({
   "nextCheckSeconds": 60
 })json";
 
-void test_serializes_required_and_hardware_fields() {
+std::string mutateResponse(
+    const std::function<void(JsonDocument &)> &mutation) {
+    JsonDocument document;
+    deserializeJson(document, VALID_RESPONSE);
+    mutation(document);
+    std::string payload;
+    serializeJson(document, payload);
+    return payload;
+}
+
+firmware::DeviceReport matchingReport() {
+    return {
+        .deviceType = "ossm",
+        .deviceId = "AA:BB:CC:DD:EE:FF",
+        .reportedTrack = "main",
+        .currentVersion = "1.0.34",
+        .currentBuild = "fedcba9876543210",
+    };
+}
+
+void test_serializes_version_identity_and_hardware_fields() {
     firmware::DeviceReport report{
         .deviceType = "ossm",
-        .deviceId = "trainer-test-id",
+        .deviceId = "AA:BB:CC:DD:EE:FF",
         .reportedTrack = "main",
         .currentVersion = "1.0.34",
         .currentBuild = "0123456789abcdef",
-        .chip = "esp32",
+        .firmwareHash =
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        .chip = "ESP32-D0WDQ6",
+        .chipRevision = 0,
+        .chipCores = 2,
+        .hardwareRevision = "ossm-v1",
         .flashSizeBytes = 4194304,
-        .partitionLayout = "legacy-v1",
+        .psramSizeBytes = 0,
+        .otaSlotSizeBytes = 1966080,
+        .partitionLayout = "ossm-ota-v1",
     };
     JsonDocument parsed;
     deserializeJson(parsed, firmware::serializeReport(report));
+    TEST_ASSERT_EQUAL_INT(1, parsed["protocolVersion"]);
     TEST_ASSERT_EQUAL_STRING("ossm", parsed["deviceType"]);
+    TEST_ASSERT_EQUAL_STRING("AA:BB:CC:DD:EE:FF", parsed["deviceId"]);
     TEST_ASSERT_EQUAL_STRING("main", parsed["reportedTrack"]);
+    TEST_ASSERT_EQUAL_STRING("1.0.34", parsed["currentVersion"]);
+    TEST_ASSERT_EQUAL_STRING("0123456789abcdef", parsed["currentBuild"]);
+    TEST_ASSERT_EQUAL_STRING(report.firmwareHash.c_str(), parsed["firmwareHash"]);
+    TEST_ASSERT_EQUAL_UINT32(0, parsed["chipRevision"]);
+    TEST_ASSERT_EQUAL_UINT32(2, parsed["chipCores"]);
     TEST_ASSERT_EQUAL_UINT32(4194304, parsed["flashSizeBytes"]);
-    TEST_ASSERT_EQUAL_STRING("legacy-v1", parsed["partitionLayout"]);
+    TEST_ASSERT_EQUAL_UINT32(0, parsed["psramSizeBytes"]);
+    TEST_ASSERT_EQUAL_UINT32(1966080, parsed["otaSlotSizeBytes"]);
+    TEST_ASSERT_EQUAL_STRING("ossm-ota-v1", parsed["partitionLayout"]);
+
+    report.otaSlotSizeBytes = 0;
+    report.chipCores = 0;
+    JsonDocument withoutOtaSlot;
+    deserializeJson(withoutOtaSlot, firmware::serializeReport(report));
+    TEST_ASSERT_TRUE(withoutOtaSlot["otaSlotSizeBytes"].isNull());
+    TEST_ASSERT_TRUE(withoutOtaSlot["chipCores"].isNull());
+    TEST_ASSERT_EQUAL_UINT32(0, withoutOtaSlot["chipRevision"]);
+    TEST_ASSERT_EQUAL_UINT32(0, withoutOtaSlot["psramSizeBytes"]);
 }
 
-void test_parses_cross_track_update_and_orders_artifacts() {
+void test_parses_canonical_decision_and_orders_artifacts() {
     firmware::Decision decision;
     std::string error;
     TEST_ASSERT_TRUE(
         firmware::parseDecision(VALID_RESPONSE, "ossm", decision, error));
-    TEST_ASSERT_TRUE(decision.updateAvailable);
+    TEST_ASSERT_TRUE(decision.shouldUpdate);
+    TEST_ASSERT_EQUAL_INT(1, decision.protocolVersion);
+    TEST_ASSERT_EQUAL_STRING("update-available", decision.reason.c_str());
     TEST_ASSERT_EQUAL_STRING("staging", decision.assignedTrack.c_str());
     TEST_ASSERT_TRUE(decision.trackChanged);
     TEST_ASSERT_EQUAL_STRING("1.0.35", decision.nextHopVersion.c_str());
+    TEST_ASSERT_EQUAL_STRING(
+        "0123456789abcdef0123456789abcdef01234567",
+        decision.buildSha.c_str());
     TEST_ASSERT_EQUAL_UINT32(1, decision.artifactCount);
     TEST_ASSERT_EQUAL_STRING("application", decision.artifacts[0].role.c_str());
+}
+
+void test_accepts_legacy_update_available_alias() {
+    const std::string payload = mutateResponse([](JsonDocument &document) {
+        document.remove("protocolVersion");
+        document.remove("shouldUpdate");
+        document.remove("reason");
+        document["update"].as<JsonObject>().remove("buildSha");
+    });
+    firmware::Decision decision;
+    std::string error;
+    TEST_ASSERT_TRUE(
+        firmware::parseDecision(payload, "ossm", decision, error));
+    TEST_ASSERT_TRUE(decision.shouldUpdate);
+    TEST_ASSERT_TRUE(decision.buildSha.empty());
+}
+
+void test_rejects_conflicting_decision_booleans_and_protocols() {
+    firmware::Decision decision;
+    std::string error;
+    std::string payload = mutateResponse(
+        [](JsonDocument &document) { document["updateAvailable"] = false; });
+    TEST_ASSERT_FALSE(
+        firmware::parseDecision(payload, "ossm", decision, error));
+
+    payload = mutateResponse(
+        [](JsonDocument &document) { document["protocolVersion"] = 2; });
+    TEST_ASSERT_FALSE(
+        firmware::parseDecision(payload, "ossm", decision, error));
+}
+
+void test_validates_canonical_reason_decision_pairing() {
+    firmware::Decision decision;
+    std::string error;
+    std::string payload = mutateResponse([](JsonDocument &document) {
+        document["reason"] = "already-current";
+    });
+    TEST_ASSERT_FALSE(
+        firmware::parseDecision(payload, "ossm", decision, error));
+
+    payload = mutateResponse([](JsonDocument &document) {
+        document["reason"] = "unexpected-reason";
+    });
+    TEST_ASSERT_FALSE(
+        firmware::parseDecision(payload, "ossm", decision, error));
+
+    payload = mutateResponse([](JsonDocument &document) {
+        document["shouldUpdate"] = false;
+        document["updateAvailable"] = false;
+        document["reason"] = "incompatible-device";
+        document["targetVersion"] = nullptr;
+        document["nextHopVersion"] = nullptr;
+        document["update"] = nullptr;
+    });
+    TEST_ASSERT_TRUE(
+        firmware::parseDecision(payload, "ossm", decision, error));
+    TEST_ASSERT_FALSE(decision.shouldUpdate);
+    TEST_ASSERT_EQUAL_STRING("incompatible-device", decision.reason.c_str());
+}
+
+void test_rejects_running_build_with_case_or_abbreviated_sha() {
+    firmware::Decision decision;
+    std::string error;
+    TEST_ASSERT_TRUE(
+        firmware::parseDecision(VALID_RESPONSE, "ossm", decision, error));
+
+    firmware::DeviceReport report = matchingReport();
+    report.currentBuild = "0123456789ABCDEF";
+    // Cross-track rebuilds are intentional because the assigned track is
+    // compiled into the firmware, even when source SHA and version match.
+    TEST_ASSERT_TRUE(
+        firmware::validateDecisionForReport(report, decision, error));
+
+    decision.assignedTrack = report.reportedTrack;
+    decision.trackChanged = false;
+    TEST_ASSERT_FALSE(
+        firmware::validateDecisionForReport(report, decision, error));
+
+    report.currentBuild = "fedcba9876543210";
+    TEST_ASSERT_TRUE(
+        firmware::validateDecisionForReport(report, decision, error));
+
+    decision.nextHopVersion = report.currentVersion;
+    TEST_ASSERT_TRUE(
+        firmware::validateDecisionForReport(report, decision, error));
+
+    decision.buildSha.clear();
+    TEST_ASSERT_FALSE(
+        firmware::validateDecisionForReport(report, decision, error));
+
+    decision.assignedTrack = "staging";
+    decision.trackChanged = true;
+    TEST_ASSERT_TRUE(
+        firmware::validateDecisionForReport(report, decision, error));
+}
+
+void test_rejects_mismatched_report_identity() {
+    firmware::Decision decision;
+    std::string error;
+    TEST_ASSERT_TRUE(
+        firmware::parseDecision(VALID_RESPONSE, "ossm", decision, error));
+    firmware::DeviceReport report = matchingReport();
+    report.currentVersion = "1.0.33";
+    TEST_ASSERT_FALSE(
+        firmware::validateDecisionForReport(report, decision, error));
 }
 
 void test_rejects_wrong_bucket_and_non_https_urls() {
@@ -84,12 +245,24 @@ void test_rejects_wrong_bucket_and_non_https_urls() {
         firmware::parseDecision(payload, "ossm", decision, error));
 }
 
-void test_rejects_bad_hash_duplicate_order_and_missing_fields() {
+void test_rejects_bad_hash_build_sha_and_missing_fields() {
     std::string payload = VALID_RESPONSE;
     const auto hash = payload.find(std::string(64, 'a'));
     payload.replace(hash, 64, "bad");
     firmware::Decision decision;
     std::string error;
+    TEST_ASSERT_FALSE(
+        firmware::parseDecision(payload, "ossm", decision, error));
+
+    payload = mutateResponse([](JsonDocument &document) {
+        document["update"]["buildSha"] = "not-a-git-sha";
+    });
+    TEST_ASSERT_FALSE(
+        firmware::parseDecision(payload, "ossm", decision, error));
+
+    payload = mutateResponse([](JsonDocument &document) {
+        document["update"].as<JsonObject>().remove("buildSha");
+    });
     TEST_ASSERT_FALSE(
         firmware::parseDecision(payload, "ossm", decision, error));
     TEST_ASSERT_FALSE(firmware::parseDecision("{}", "ossm", decision, error));
@@ -99,9 +272,14 @@ void test_rejects_bad_hash_duplicate_order_and_missing_fields() {
 
 int main(int, char **) {
     UNITY_BEGIN();
-    RUN_TEST(test_serializes_required_and_hardware_fields);
-    RUN_TEST(test_parses_cross_track_update_and_orders_artifacts);
+    RUN_TEST(test_serializes_version_identity_and_hardware_fields);
+    RUN_TEST(test_parses_canonical_decision_and_orders_artifacts);
+    RUN_TEST(test_accepts_legacy_update_available_alias);
+    RUN_TEST(test_rejects_conflicting_decision_booleans_and_protocols);
+    RUN_TEST(test_validates_canonical_reason_decision_pairing);
+    RUN_TEST(test_rejects_running_build_with_case_or_abbreviated_sha);
+    RUN_TEST(test_rejects_mismatched_report_identity);
     RUN_TEST(test_rejects_wrong_bucket_and_non_https_urls);
-    RUN_TEST(test_rejects_bad_hash_duplicate_order_and_missing_fields);
+    RUN_TEST(test_rejects_bad_hash_build_sha_and_missing_fields);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- Standardize firmware checks on protocol v1 with canonical `shouldUpdate`,
  strict decision reasons, and a legacy `updateAvailable` mirror.
- Report immutable build identity, running firmware SHA-256, stable device ID,
  physical flash, OTA-slot capacity, chip revision/core count, PSRAM, and
  partition layout.
- Stop repeated same-build/migration offers, enforce rollout and 4 MB / 16 MB
  compatibility, and filter install plans to supported required artifacts.
- Persist failed Lockbox release attempts so fallback boots do not
  automatically retry the same immutable release.
- Preserve deployed OSSM and DTT update bridges by restoring the numeric fields
  required in legacy `version.json` aliases.
- Keep every existing partition layout and rollback configuration unchanged.

## Validation

- RAD App firmware resolver/API suite: 61/61
- OSSM native suite: 208/208
- Lockbox native suite: 54/54
- DTT native suite: 12/12
- RADR native suite: 7/7
- Staging and production link/size checks pass for all four firmware families.
- Publisher, legacy-alias, and workflow regression suites pass.
- Type checks, focused lint/format checks, and `git diff --check` pass.
- No partition, PlatformIO, or SDK configuration diff is included.

Local database integration requires CI because the available local Supabase
instance does not contain the new `admin` schema.

## Rollout notes

This targets `staging` only. Promotion to production remains a separate manual
review.

Previously deployed RADR 1.0.42 and older contain a state-machine wiring defect
that prevents their updater from invoking the download tasks. Devices already
on 1.0.43 can use the new chain; older units need an external application-only
bootstrap before they can enter it.

Physical flashing and failure injection were not attempted because the hardware
safety camera/API gate was unavailable.

<!-- rad-bundle:start -->
Cross-repository bundle: `AJ/update-loop-guard`

- [rad-app #1622](https://github.com/researchanddesire/rad-app/pull/1622)
- [ossm #302](https://github.com/KinkyMakers/OSSM-hardware/pull/302)
- [lkbx #492](https://github.com/researchanddesire/Lockbox/pull/492)
- [dtt #209](https://github.com/researchanddesire/DT_Trainer/pull/209)
- [radr #109](https://github.com/researchanddesire/radr-wireless-remote/pull/109)
<!-- rad-bundle:end -->
