### PR TITLE
Restore protected firmware candidate publishing

### DIFF
--- a/.github/scripts/test_release_workflow.py
+++ b/.github/scripts/test_release_workflow.py
@@ -7,6 +7,18 @@ from release_workflow import branch_configuration, main, tag_action
 
 
 class ReleaseWorkflowTests(unittest.TestCase):
+    def test_publisher_uses_scoped_deploy_key_for_git_writes(self):
+        workflow = (
+            Path(__file__).resolve().parents[1] / "workflows" / "publish_firmware.yml"
+        ).read_text()
+        self.assertIn(
+            "ssh-key: ${{ secrets.RAD_VERSION_CONTROL_DEPLOY_KEY }}", workflow
+        )
+        self.assertNotRegex(
+            workflow, r"(?m)^\s+token:\s+\$\{\{ github\.token \}\}$"
+        )
+        self.assertIn("github-token: ${{ github.token }}", workflow)
+
     def test_branch_configuration_maps_tracks_and_projects(self):
         self.assertEqual(branch_configuration("main")["PIO_ENV"], "production")
         self.assertEqual(branch_configuration("staging")["PIO_ENV"], "staging")

--- a/.github/workflows/publish_firmware.yml
+++ b/.github/workflows/publish_firmware.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-          token: ${{ github.token }}
+          ssh-key: ${{ secrets.RAD_VERSION_CONTROL_DEPLOY_KEY }}
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary

- Merge the current production history back into staging before the next
  production promotion.
- Keep the canonical update protocol, hardware telemetry, same-build
  convergence guards, and OTA retry protections already on staging.
- Use the OSSM-only firmware deploy key for protected-branch version writes
  while retaining the default workflow token for read-only PR metadata.
- Add a regression test that rejects use of the default workflow token for the
  publisher checkout.

## Repository configuration

- The deploy key is the repository's only deploy key and has write access.
- Its private key is stored only as `RAD_VERSION_CONTROL_DEPLOY_KEY` in the
  branch-restricted `firmware-staging` and `firmware-production` environments.
- The `main` and `staging` rulesets admit deploy keys while preserving their PR
  and required-check rules for every other actor.

## Validation

- Publisher, download, release-workflow, and version-helper tests pass.
- The full pre-change validation remains green: 208 native tests, clang-tidy,
  staging build, and production build.
- `git diff --check` passes.

This PR targets staging. Production promotion remains a separate manual review.

<!-- rad-bundle:start -->
Cross-repository bundle: `AJ/promotion-ci-repair`

- [ossm #304](https://github.com/KinkyMakers/OSSM-hardware/pull/304)
<!-- rad-bundle:end -->
