### PR TITLE
Gate OSSM telemetry until paired

### DIFF
--- a/Software/src/main.cpp
+++ b/Software/src/main.cpp
@@ -4,6 +4,7 @@
 #include "esp_log.h"
 #include "ossm/Events.h"
 #include "ossm/OSSM.h"
+#include "ossm/pages/pairing.h"
 #include "ossm/state/state.h"
 #include "services/board.h"
 #include "services/communication/mqtt.h"
@@ -101,6 +102,7 @@ void __attribute__((weak)) setup() {
                     initNimble();
                     initWM();
                     initMQTT();
+                    pages::startPairingStatusCheck();
                     initialized = true;
                     vTaskDelete(nullptr);
                 }

--- a/Software/src/ossm/pages/pairing.cpp
+++ b/Software/src/ossm/pages/pairing.cpp
@@ -18,6 +18,49 @@ using namespace sml;
 namespace pages {
 
 static String pairingCode = "";
+static volatile bool paired = false;
+
+static int requestDeviceAuth(bool updatePairingCode) {
+    if (WiFi.status() != WL_CONNECTED) {
+        return HTTP_CODE_SERVICE_UNAVAILABLE;
+    }
+
+    String macAddress = WiFi.macAddress();
+    HTTPClient http;
+    String url = String(RAD_SERVER) + "/api/ossm/auth";
+    http.begin(url);
+    http.addHeader("Content-Type", "application/json");
+
+    JsonDocument doc;
+    doc["mac"] = macAddress;
+    doc["chip"] = String((uint32_t)ESP.getEfuseMac(), HEX);
+    doc["md5"] = ESP.getSketchMD5();
+    doc["device"] = "OSSM";
+    doc["version"] = VERSION;
+
+    String body;
+    serializeJson(doc, body);
+
+    int httpCode = http.POST(body);
+    if (httpCode == HTTP_CODE_OK) {
+        JsonDocument response;
+        DeserializationError jsonError =
+            deserializeJson(response, http.getString());
+        if (jsonError) {
+            ESP_LOGW("PAIRING", "Invalid auth response: %s",
+                     jsonError.c_str());
+            http.end();
+            return HTTP_CODE_INTERNAL_SERVER_ERROR;
+        }
+
+        paired = response["isPaired"].as<bool>();
+        if (updatePairingCode) {
+            pairingCode = response["pairingCode"].as<String>();
+        }
+    }
+    http.end();
+    return httpCode;
+}
 
 static void drawPairingScreen() {
     showHeaderIcons = false;
@@ -46,44 +89,19 @@ static void pairingTask(void *pvParameters) {
         xSemaphoreGive(displayMutex);
     }
 
-    String macAddress = WiFi.macAddress();
+    int httpCode = requestDeviceAuth(true);
 
-    HTTPClient http;
-    String url = String(RAD_SERVER) + "/api/ossm/auth";
-    http.begin(url);
-    http.addHeader("Content-Type", "application/json");
-
-    JsonDocument doc;
-    doc["mac"] = macAddress;
-    doc["chip"] = String((uint32_t)ESP.getEfuseMac(), HEX);
-    doc["md5"] = ESP.getSketchMD5();
-    doc["device"] = "OSSM";
-    doc["version"] = VERSION;
-
-    String body;
-    serializeJson(doc, body);
-
-    ESP_LOGI("PAIRING", "POST %s", url.c_str());
-    int httpCode = http.POST(body);
-
-    if (httpCode != 200) {
+    if (httpCode != HTTP_CODE_OK) {
         ESP_LOGW("PAIRING", "Auth failed with HTTP %d", httpCode);
-        http.end();
         stateMachine->process_event(Error{});
         vTaskDelete(nullptr);
         return;
     }
 
-    String payload = http.getString();
-    http.end();
+    ESP_LOGI("PAIRING", "Auth response: code=%s isPaired=%d",
+             pairingCode.c_str(), paired);
 
-    JsonDocument resp;
-    deserializeJson(resp, payload);
-    pairingCode = resp["pairingCode"].as<String>();
-    bool isPaired = resp["isPaired"].as<bool>();
-    ESP_LOGI("PAIRING", "Auth response: code=%s isPaired=%d", pairingCode.c_str(), isPaired);
-
-    if (isPaired) {
+    if (paired) {
         stateMachine->process_event(Done{});
         vTaskDelete(nullptr);
         return;
@@ -131,6 +149,34 @@ static void pairingTask(void *pvParameters) {
 void checkPairing() {
     ESP_LOGI("PAIRING", "checkPairing action triggered");
     xTaskCreatePinnedToCore(pairingTask, "pairingTask",
+                            20 * configMINIMAL_STACK_SIZE, nullptr, 1, nullptr,
+                            0);
+}
+
+static void pairingStatusTask(void *pvParameters) {
+    while (!paired) {
+        if (WiFi.status() == WL_CONNECTED) {
+            int httpCode = requestDeviceAuth(false);
+            if (httpCode != HTTP_CODE_OK) {
+                ESP_LOGW("PAIRING", "Pairing status check failed with HTTP %d",
+                         httpCode);
+            } else {
+                ESP_LOGI("PAIRING", "Pairing status: isPaired=%d", paired);
+            }
+        }
+
+        if (!paired) {
+            vTaskDelay(pdMS_TO_TICKS(60000));
+        }
+    }
+
+    vTaskDelete(nullptr);
+}
+
+bool isOssmPaired() { return paired; }
+
+void startPairingStatusCheck() {
+    xTaskCreatePinnedToCore(pairingStatusTask, "pairingStatusTask",
                             20 * configMINIMAL_STACK_SIZE, nullptr, 1, nullptr,
                             0);
 }

--- a/Software/src/ossm/pages/pairing.h
+++ b/Software/src/ossm/pages/pairing.h
@@ -5,6 +5,8 @@ namespace pages {
 
 void checkPairing();
 void drawPairingSuccess();
+bool isOssmPaired();
+void startPairingStatusCheck();
 
 }  // namespace pages
 

--- a/Software/src/ossm/stroke_engine/stroke_engine.cpp
+++ b/Software/src/ossm/stroke_engine/stroke_engine.cpp
@@ -4,6 +4,7 @@
 
 #include "constants/UserConfig.h"
 #include "ossm/OSSM.h"
+#include "ossm/pages/pairing.h"
 #include "ossm/state/ble.h"
 #include "ossm/state/calibration.h"
 #include "ossm/state/settings.h"
@@ -163,7 +164,7 @@ static void publishStateTask(void *pvParameters) {
     TickType_t lastWakeTime = xTaskGetTickCount();
 
     while (isInCorrectState()) {
-        if (!mqttConnected) {
+        if (!mqttConnected || !pages::isOssmPaired()) {
             vTaskDelay(pdMS_TO_TICKS(1000));
             lastWakeTime = xTaskGetTickCount();
             continue;


### PR DESCRIPTION
## Summary
- authenticate OSSM devices at boot and poll until pairing completes
- prevent MQTT telemetry publication before the server confirms ownership
- reuse the pairing authentication path for foreground and background checks

## Validation
- 208 PlatformIO unit tests pass
- staging firmware build passes
- production firmware build passes
- PlatformIO static analysis reports 0 high-severity defects (82 existing medium warnings)

## Dashboard
Companion dashboard/database fix: https://github.com/researchanddesire/rad-app/pull/1635