### PR TITLE
Add persistent BLE names and device identity

### DIFF
--- a/Software/lib/RadBLE/src/RadBle.cpp
+++ b/Software/lib/RadBLE/src/RadBle.cpp
@@ -1,5 +1,6 @@
 #include "RadBle.h"
 
+#include <Preferences.h>
 #include <Update.h>
 #include <WiFi.h>
 #include <ctype.h>
@@ -17,6 +18,7 @@ namespace {
 
 enum QueueKind : uint8_t {
     QUEUE_REQUEST = 0,
+    QUEUE_DEVICE_NAME,
     QUEUE_BUTTON,
     QUEUE_ENCODER,
     QUEUE_INDICATOR,
@@ -73,6 +75,8 @@ uint8_t queueKindForSurface(Surface surface) {
 
 const char* operationForKind(uint8_t kind) {
     switch (kind) {
+        case QUEUE_DEVICE_NAME:
+            return "setting.write";
         case QUEUE_BUTTON:
             return "input.emit";
         case QUEUE_ENCODER:
@@ -173,6 +177,23 @@ void characteristicUuid(const char* serviceUuid, const char* suffix,
 
 }  // namespace
 
+String loadDeviceName(const char* fallback) {
+    const String defaultName = fallback == nullptr ? "RAD" : fallback;
+    Preferences preferences;
+    if (!preferences.begin("radble", true)) return defaultName;
+    const String value = preferences.getString("deviceName", defaultName);
+    preferences.end();
+    return value.isEmpty() ? defaultName : value;
+}
+
+bool persistDeviceName(const String& name) {
+    Preferences preferences;
+    if (!preferences.begin("radble", false)) return false;
+    const bool stored = preferences.putString("deviceName", name) == name.length();
+    preferences.end();
+    return stored;
+}
+
 struct Server::QueueMessage {
     uint8_t kind;
     uint16_t connectionHandle;
@@ -200,6 +221,9 @@ bool Server::begin(NimBLEServer* server, const Config& config) {
 
     server_ = server;
     config_ = config;
+    deviceName_ = loadDeviceName(config_.deviceName == nullptr
+                                     ? config_.deviceType
+                                     : config_.deviceName);
     for (size_t index = 0; index < RESPONSE_CACHE_SIZE; ++index)
         responseCacheConnections_[index] = 0xffff;
     queue_ = xQueueCreate(16, sizeof(QueueMessage));
@@ -212,13 +236,37 @@ bool Server::begin(NimBLEServer* server, const Config& config) {
 
     char characteristicUuidValue[37];
     characteristicUuid(config_.serviceUuid, "0002", characteristicUuidValue);
-    auto* protocolInfo = service_->getCharacteristic(characteristicUuidValue);
-    if (protocolInfo == nullptr)
-        protocolInfo = service_->createCharacteristic(
+    protocolInfoCharacteristic_ =
+        service_->getCharacteristic(characteristicUuidValue);
+    if (protocolInfoCharacteristic_ == nullptr)
+        protocolInfoCharacteristic_ = service_->createCharacteristic(
             characteristicUuidValue, NIMBLE_PROPERTY::READ, MAX_MESSAGE_BYTES);
     const String protocolInfoValue = protocolInfoJson();
     if (protocolInfoValue.length() > MAX_MESSAGE_BYTES) return false;
-    protocolInfo->setValue(protocolInfoValue.c_str());
+    protocolInfoCharacteristic_->setValue(protocolInfoValue.c_str());
+
+    characteristicUuid(config_.serviceUuid, "0004", characteristicUuidValue);
+    deviceNameCharacteristic_ =
+        service_->getCharacteristic(characteristicUuidValue);
+    if (deviceNameCharacteristic_ == nullptr) {
+        deviceNameCharacteristic_ = service_->createCharacteristic(
+            characteristicUuidValue,
+            NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE |
+                NIMBLE_PROPERTY::NOTIFY,
+            MAX_MESSAGE_BYTES);
+        deviceNameCharacteristic_->setCallbacks(
+            new WriteCallbacks(this, QUEUE_DEVICE_NAME));
+    }
+    deviceNameCharacteristic_->setValue(deviceNameJson().c_str());
+
+    characteristicUuid(config_.serviceUuid, "0005", characteristicUuidValue);
+    deviceIdentityCharacteristic_ =
+        service_->getCharacteristic(characteristicUuidValue);
+    if (deviceIdentityCharacteristic_ == nullptr)
+        deviceIdentityCharacteristic_ = service_->createCharacteristic(
+            characteristicUuidValue, NIMBLE_PROPERTY::READ,
+            MAX_MESSAGE_BYTES);
+    deviceIdentityCharacteristic_->setValue(deviceIdentityJson().c_str());
 
     characteristicUuid(config_.serviceUuid, "0003", characteristicUuidValue);
     auto* catalog = service_->getCharacteristic(characteristicUuidValue);
@@ -396,6 +444,22 @@ bool Server::begin(NimBLEServer* server, const Config& config) {
             ->setValue(config_.firmwareVersion == nullptr
                            ? "unknown"
                            : config_.firmwareVersion);
+    if (deviceInfo->getCharacteristic("2A25") == nullptr) {
+        const uint64_t efuseMac = ESP.getEfuseMac();
+        char serial[13];
+        snprintf(serial, sizeof(serial), "%04lx%08lx",
+                 static_cast<unsigned long>((efuseMac >> 32) & 0xffffU),
+                 static_cast<unsigned long>(efuseMac & 0xffffffffU));
+        deviceInfo->createCharacteristic("2A25", NIMBLE_PROPERTY::READ)
+            ->setValue(serial);
+    }
+    if (deviceInfo->getCharacteristic("2A27") == nullptr)
+        deviceInfo->createCharacteristic("2A27", NIMBLE_PROPERTY::READ)
+            ->setValue(String(ESP.getChipModel()) + " rev " +
+                       String(ESP.getChipRevision()));
+    if (deviceInfo->getCharacteristic("2A28") == nullptr)
+        deviceInfo->createCharacteristic("2A28", NIMBLE_PROPERTY::READ)
+            ->setValue(config_.build == nullptr ? "unknown" : config_.build);
 
     if (config_.capabilities & CAP_POWER) {
         auto* batteryService = server_->getServiceByUUID("180F");
@@ -424,6 +488,16 @@ bool Server::begin(NimBLEServer* server, const Config& config) {
     Serial.printf("[RAD BLE] v1 service ready for %s (%u resources)\n",
                   config_.deviceType,
                   static_cast<unsigned>(config_.resourceCount));
+    Serial.printf("[RAD BLE] device name loaded name=\"%s\" source=%s\n",
+                  deviceName_.c_str(),
+                  deviceName_ == config_.deviceType ? "default" : "custom");
+    Serial.printf(
+        "[RAD BLE] identity manufacturer=\"Research and Desire\" "
+        "website=https://www.researchanddesire.com model=%s firmware=%s "
+        "hardware=%s flashSizeBytes=%u\n",
+        config_.deviceType,
+        config_.firmwareVersion == nullptr ? "unknown" : config_.firmwareVersion,
+        ESP.getChipModel(), static_cast<unsigned>(ESP.getFlashChipSize()));
     return true;
 }
 
@@ -459,6 +533,130 @@ NimBLECharacteristic* Server::createSurfaceCharacteristic(
     surfaces_[static_cast<size_t>(surface)] = characteristic;
     return characteristic;
 }
+
+String Server::deviceNameJson() const {
+    JsonDocument document;
+    document["name"] = deviceName_;
+    document["default"] = config_.deviceType;
+    document["custom"] = deviceName_ != config_.deviceType;
+    document["maxBytes"] = DEVICE_NAME_MAX_BYTES;
+    String value;
+    serializeJson(document, value);
+    return value;
+}
+
+String Server::deviceIdentityJson() const {
+    const uint64_t efuseMac = ESP.getEfuseMac();
+    char serial[13];
+    snprintf(serial, sizeof(serial), "%04lx%08lx",
+             static_cast<unsigned long>((efuseMac >> 32) & 0xffffU),
+             static_cast<unsigned long>(efuseMac & 0xffffffffU));
+    JsonDocument document;
+    document["manufacturer"] = "Research and Desire";
+    document["website"] = "https://www.researchanddesire.com";
+    document["model"] = config_.deviceType;
+    document["name"] = deviceName_;
+    document["serial"] = serial;
+    document["firmwareVersion"] = config_.firmwareVersion == nullptr
+                                      ? "unknown"
+                                      : config_.firmwareVersion;
+    document["build"] = config_.build == nullptr ? "unknown" : config_.build;
+    document["hardware"] = ESP.getChipModel();
+    document["hardwareRevision"] = ESP.getChipRevision();
+    document["flashSizeBytes"] = ESP.getFlashChipSize();
+    String value;
+    serializeJson(document, value);
+    return value;
+}
+
+void Server::refreshDeviceNameCharacteristics(bool notify) {
+    if (deviceNameCharacteristic_ != nullptr) {
+        deviceNameCharacteristic_->setValue(deviceNameJson().c_str());
+        if (notify) deviceNameCharacteristic_->notify();
+    }
+    if (protocolInfoCharacteristic_ != nullptr)
+        protocolInfoCharacteristic_->setValue(protocolInfoJson().c_str());
+    if (deviceIdentityCharacteristic_ != nullptr)
+        deviceIdentityCharacteristic_->setValue(deviceIdentityJson().c_str());
+}
+
+Result Server::handleDeviceName(JsonObjectConst request) {
+    const String operation = request["op"] | "";
+    if (operation == "setting.read") return Result::success(deviceNameJson());
+
+    String requested;
+    if (operation == "setting.reset") {
+        requested = config_.deviceType;
+    } else {
+        if (!request["args"]["value"].is<const char*>()) {
+            Serial.println(
+                "[RAD BLE] device name rejected code=invalid_value reason=missing_string");
+            return Result::failure("invalid_value",
+                                   "Device name value must be a string");
+        }
+        requested = request["args"]["value"].as<const char*>();
+        requested.trim();
+        if (requested.isEmpty()) requested = config_.deviceType;
+    }
+
+    if (requested.length() > DEVICE_NAME_MAX_BYTES) {
+        Serial.printf(
+            "[RAD BLE] device name rejected code=invalid_value bytes=%u max=%u\n",
+            static_cast<unsigned>(requested.length()),
+            static_cast<unsigned>(DEVICE_NAME_MAX_BYTES));
+        return Result::failure("invalid_value",
+                               "Device name exceeds the 24-byte limit");
+    }
+    for (size_t index = 0; index < requested.length(); ++index) {
+        const unsigned char value = requested[index];
+        if (!(isalnum(value) || value == ' ' || value == '-' || value == '_' ||
+              value == '.')) {
+            Serial.printf(
+                "[RAD BLE] device name rejected code=invalid_value byte=%u\n",
+                static_cast<unsigned>(value));
+            return Result::failure(
+                "invalid_value",
+                "Device name allows letters, numbers, spaces, dot, dash, and underscore");
+        }
+    }
+
+    const String previous = deviceName_;
+    if (requested != previous) {
+        if (!persistDeviceName(requested)) {
+            Serial.println(
+                "[RAD BLE] device name rejected code=storage_failed");
+            return Result::failure("storage_failed",
+                                   "Could not persist the device name");
+        }
+        deviceName_ = requested;
+        NimBLEDevice::setDeviceName(deviceName_.c_str());
+        auto* advertising = NimBLEDevice::getAdvertising();
+        if (advertising != nullptr) advertising->setName(deviceName_.c_str());
+        refreshDeviceNameCharacteristics(true);
+        Serial.printf(
+            "[RAD BLE] device name changed old=\"%s\" new=\"%s\" source=ble\n",
+            previous.c_str(), deviceName_.c_str());
+
+        JsonDocument event;
+        event["event"] = "device.name.changed";
+        event["name"] = deviceName_;
+        String eventJson;
+        serializeJson(event, eventJson);
+        publishEvent(eventJson);
+    }
+
+    JsonDocument result;
+    result["name"] = deviceName_;
+    result["default"] = config_.deviceType;
+    result["custom"] = deviceName_ != config_.deviceType;
+    result["changed"] = deviceName_ != previous;
+    result["maxBytes"] = DEVICE_NAME_MAX_BYTES;
+    String resultJson;
+    serializeJson(result, resultJson);
+    return Result::success(resultJson);
+}
+
+
 
 bool Server::enqueue(uint8_t kind, uint16_t connectionHandle,
                      const uint8_t* data, size_t length) {
@@ -538,6 +736,14 @@ void Server::dispatchRequest(const QueueMessage& message) {
     if (!document["id"].is<uint32_t>()) document["id"] = esp_random();
     if (document["v"].isNull()) document["v"] = PROTOCOL_VERSION;
     if (document["op"].isNull()) document["op"] = operationForKind(message.kind);
+    if (message.kind == QUEUE_DEVICE_NAME) {
+        if (document["path"].isNull()) document["path"] = "device.name";
+        JsonObject args = document["args"].is<JsonObject>()
+                              ? document["args"].as<JsonObject>()
+                              : document["args"].to<JsonObject>();
+        if (args["value"].isNull() && !document["name"].isNull())
+            args["value"] = document["name"];
+    }
 
     if (message.kind == QUEUE_OTA_CONTROL &&
         String(document["op"] | "") == "ota.control") {
@@ -907,6 +1113,11 @@ void Server::dispatchRequest(const QueueMessage& message) {
         } else if (result.ok) {
             result = Result::success(R"({"requested":true})");
         }
+    } else if (String(document["path"] | "") == "device.name" &&
+               (operation == "setting.read" ||
+                operation == "setting.write" ||
+                operation == "setting.reset")) {
+        result = handleDeviceName(document.as<JsonObjectConst>());
     } else
         result = config_.commandHandler(document.as<JsonObjectConst>(),
                                         config_.context);
@@ -1577,9 +1788,7 @@ String Server::protocolInfoJson(bool compact) const {
     document["directOta"] = config_.directOta;
     document["directFilesystemOta"] = config_.directFilesystemOta;
     if (!compact) {
-        document["deviceName"] = config_.deviceName == nullptr
-                                     ? config_.deviceType
-                                     : config_.deviceName;
+        document["deviceName"] = deviceName_;
         document["firmwareVersion"] = config_.firmwareVersion == nullptr
                                           ? "unknown"
                                           : config_.firmwareVersion;

--- a/Software/lib/RadBLE/src/RadBle.h
+++ b/Software/lib/RadBLE/src/RadBle.h
@@ -25,6 +25,10 @@ inline constexpr uint8_t PROTOCOL_VERSION = 1;
 // long-read behavior for asynchronous responses.
 inline constexpr size_t MAX_MESSAGE_BYTES = 509;
 inline constexpr size_t STREAM_HEADER_BYTES = 20;
+inline constexpr size_t DEVICE_NAME_MAX_BYTES = 24;
+
+String loadDeviceName(const char* fallback);
+bool persistDeviceName(const String& name);
 
 enum class Surface : uint8_t {
     State,
@@ -154,6 +158,10 @@ class Server {
     void dispatch(const QueueMessage& message);
     void dispatchRequest(const QueueMessage& message);
     void dispatchOtaData(const QueueMessage& message);
+    Result handleDeviceName(JsonObjectConst request);
+    void refreshDeviceNameCharacteristics(bool notify);
+    String deviceNameJson() const;
+    String deviceIdentityJson() const;
     Result beginOta(JsonObjectConst request, uint16_t connectionHandle);
     Result finishOta(JsonObjectConst request, uint16_t connectionHandle);
     Result abortOta(const char* code, const char* message,
@@ -187,6 +195,9 @@ class Server {
     Config config_{};
     NimBLEServer* server_ = nullptr;
     NimBLEService* service_ = nullptr;
+    NimBLECharacteristic* protocolInfoCharacteristic_ = nullptr;
+    NimBLECharacteristic* deviceNameCharacteristic_ = nullptr;
+    NimBLECharacteristic* deviceIdentityCharacteristic_ = nullptr;
     NimBLECharacteristic* responseCharacteristic_ = nullptr;
     NimBLECharacteristic* eventCharacteristic_ = nullptr;
     NimBLECharacteristic* streamCharacteristic_ = nullptr;
@@ -209,6 +220,7 @@ class Server {
     uint32_t lastStateHeartbeatAt_ = 0;
     uint32_t stateSequence_ = 0;
     String lastDeviceStateSnapshot_;
+    String deviceName_;
     String activeOperation_;
     bool streamActive_ = false;
     Surface streamSurface_ = Surface::State;

--- a/Software/src/services/communication/nimble.cpp
+++ b/Software/src/services/communication/nimble.cpp
@@ -33,6 +33,23 @@ static int speedOnLostConnection = 0;
 static const unsigned long RAMP_DURATION_MS =
     2000;  // Duration for speed ramp to zero
 
+void restartAdvertisingWithCurrentName() {
+    const std::string deviceName = getDeviceName();
+    NimBLEAdvertising* advertising = NimBLEDevice::getAdvertising();
+    advertising->stop();
+    advertising->clearData();
+    advertising->enableScanResponse(true);
+    advertising->setName(deviceName);
+    advertising->addServiceUUID(SERVICE_UUID);
+    advertising->addServiceUUID(DEVICE_INFO_SERVICE_UUID);
+#ifdef PRETEND_TO_BE_FLESHY_THRUST_SYNC
+    advertising->addServiceUUID("0000ffe0-0000-1000-8000-00805f9b34fb");
+#endif
+    NimBLEDevice::setDeviceName(deviceName);
+    ESP_LOGI(NIMBLE_TAG, "Advertising as: %s", deviceName.c_str());
+    advertising->start();
+}
+
 double easeInOutSine(double t) {
     return 0.5 * (1 + sin(3.1415926 * (t - 0.5)));
 }
@@ -76,8 +93,7 @@ class ServerCallbacks : public NimBLEServerCallbacks {
         if (pServer->getConnectedCount() == 0) {
             ESP_LOGI(NIMBLE_TAG,
                      "No connections remaining, restarting advertising");
-            NimBLEDevice::setDeviceName(getDeviceName());
-            pServer->startAdvertising();
+            restartAdvertisingWithCurrentName();
         }
 
         lostConnectionTime = millis();
@@ -162,7 +178,7 @@ void nimbleLoop(void* pvParameters) {
                 ESP_LOGI(NIMBLE_TAG,
                          "No connections and not advertising, restarting "
                          "advertising");
-                pServer->startAdvertising();
+                restartAdvertisingWithCurrentName();
             }
 
             if (lostConnectionTime > 0) {
@@ -359,21 +375,11 @@ void initNimble() {
     pFTS->start();
 #endif
 
-    // Update advertising to include new services
-    NimBLEAdvertising* pAdvertising = NimBLEDevice::getAdvertising();
-    pAdvertising->setName(getDeviceName());
-    pAdvertising->addServiceUUID(pService->getUUID());
-    pAdvertising->addServiceUUID(pDeviceInfoService->getUUID());
-#ifdef PRETEND_TO_BE_FLESHY_THRUST_SYNC
-    pAdvertising->addServiceUUID(pFTS->getUUID());
-#endif
-    pAdvertising->enableScanResponse(true);
-
     // // Configure advertising parameters for better reliability
     // pAdvertising->setMinInterval(0x20);  // 20ms minimum interval
     // pAdvertising->setMaxInterval(0x40);  // 40ms maximum interval
 
-    pAdvertising->start();
+    restartAdvertisingWithCurrentName();
 
     xTaskCreatePinnedToCore(
         nimbleLoop, "nimbleLoop", 5 * configMINIMAL_STACK_SIZE, pServer,

--- a/Software/src/services/communication/rad_ble.cpp
+++ b/Software/src/services/communication/rad_ble.cpp
@@ -83,7 +83,7 @@ const radble::Resource RESOURCES[] = {
     {"mqtt_rate", "setting.mqttPublishFrequency", "setting", "float", "Hz",
      RW, "{\"min\":1,\"max\":100}"},
     {"device_name", "device.name", "setting", "string", "", RWP,
-     "{\"maxLength\":8}"},
+     "{\"maxBytes\":24,\"emptyResets\":true}"},
     {"calibration_offset", "motion.currentOffset", "motion", "float", "raw",
      R, ""},
     {"calibration_stroke", "motion.measuredStroke", "motion", "float", "steps",

--- a/Software/src/services/communication/rename.hpp
+++ b/Software/src/services/communication/rename.hpp
@@ -9,9 +9,24 @@
 std::string getDeviceName() {
     Preferences userConfig;
     userConfig.begin("UserConfig", true);
-    std::string output = userConfig.getString("DeviceName","OSSM").c_str();
+    String legacyName = userConfig.getString("DeviceName", "OSSM");
     userConfig.end();
-    return output;
+    return radble::loadDeviceName(legacyName.c_str()).c_str();
+}
+
+bool isValidLegacyDeviceName(const String& value) {
+    for (size_t index = 0; index < value.length(); ++index) {
+        const char character = value[index];
+        const bool valid =
+            (character >= 'a' && character <= 'z') ||
+            (character >= 'A' && character <= 'Z') ||
+            (character >= '0' && character <= '9') || character == ' ' ||
+            character == '-' || character == '_' || character == '.';
+        if (!valid) {
+            return false;
+        }
+    }
+    return true;
 }
 
 class RenameConfigCallbacks : public NimBLECharacteristicCallbacks {
@@ -21,11 +36,34 @@ class RenameConfigCallbacks : public NimBLECharacteristicCallbacks {
         u32_t currentTime = millis();
         if (currentTime - lastPresetCommand > 1000) {
             String value = pCharacteristic->getValue();
-            value = value.substring(0,8);
+            value.trim();
+            value = value.substring(0, radble::DEVICE_NAME_MAX_BYTES);
+            if (value.isEmpty()) {
+                value = "OSSM";
+            }
+            if (!isValidLegacyDeviceName(value)) {
+                Serial.printf(
+                    "[RAD BLE] device name rejected reason=invalid_characters "
+                    "source=legacy\n");
+                lastPresetCommand = currentTime;
+                return;
+            }
+            const std::string oldName = getDeviceName();
+            if (!radble::persistDeviceName(value)) {
+                Serial.printf(
+                    "[RAD BLE] device name rejected reason=persist_failed "
+                    "source=legacy\n");
+                lastPresetCommand = currentTime;
+                return;
+            }
             Preferences userConfig;
             userConfig.begin("UserConfig", false);
             userConfig.putString("DeviceName", value);
             userConfig.end();
+            Serial.printf(
+                "[RAD BLE] device name changed old=\"%s\" new=\"%s\" "
+                "source=legacy\n",
+                oldName.c_str(), value.c_str());
             ESP_LOGI("NIMBLE_RENAME", "Rename write: %s", value.c_str());
             ESP.restart();
         }


### PR DESCRIPTION
## Summary

- add a shared persistent, lease-protected BLE device-name characteristic and `device.name` catalog resource
- update the GAP and scan-response local name immediately and preserve it across restart
- expose Research and Desire device identity, firmware, hardware serial, chip revision, and physical flash size through a read-only characteristic and the standard Device Information Service
- document and contract-test the shared UUIDs and payloads in RadApp
- rebuild OSSM advertising data after a runtime rename so its legacy BLE service cannot retain a stale local name

## Validation

- built and flashed the staging firmware on attached DTT, LKBX, OSSM, and RADR hardware
- verified direct characteristic write, readback, notification, custom advertisement, restart persistence, invalid-character rejection, 24-byte limit, reset, and restored advertisement on every device
- correlated requests and terminal responses against each device's live USB serial log
- confirmed all four devices report 16,777,216 physical flash bytes
- passed RadApp protocol typecheck and the targeted BLE suite (9 tests)
- BLE OTA intentionally excluded

<!-- rad-bundle:start -->
Cross-repository bundle: `AJ/BLECustomDeviceNames`

- [rad-app #1640](https://github.com/researchanddesire/rad-app/pull/1640)
- [ossm #309](https://github.com/KinkyMakers/OSSM-hardware/pull/309)
- [lkbx #496](https://github.com/researchanddesire/Lockbox/pull/496)
- [dtt #212](https://github.com/researchanddesire/DT_Trainer/pull/212)
- [radr #114](https://github.com/researchanddesire/radr-wireless-remote/pull/114)
<!-- rad-bundle:end -->
