### PR TITLE
Add essential BLE state telemetry

### DIFF
--- a/Software/lib/RadBLE/src/RadBle.cpp
+++ b/Software/lib/RadBLE/src/RadBle.cpp
@@ -137,7 +137,7 @@ void writeU32(uint8_t* target, uint32_t value) {
 
 const char* surfaceName(Surface surface) {
     static const char* names[] = {
-        "state",       "button", "encoder", "imu",     "power",
+        "state",       "essential", "button", "encoder", "imu",     "power",
         "analog",      "magnetic", "motion", "connectivity",
         "indicator",   "haptic", "audio", "display",
     };
@@ -307,6 +307,20 @@ bool Server::begin(NimBLEServer* server, const Config& config) {
         service_->getCharacteristic(characteristicUuidValue);
     if (surfaces_[static_cast<size_t>(Surface::State)] == nullptr)
         surfaces_[static_cast<size_t>(Surface::State)] =
+            service_->createCharacteristic(
+                characteristicUuidValue,
+                NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY,
+                MAX_MESSAGE_BYTES);
+
+    // One stable, common subscription for the user-facing state that matters
+    // most. Product adapters keep this compact and change-driven so clients do
+    // not need to discover several category characteristics just to render a
+    // useful live status view.
+    characteristicUuid(config_.serviceUuid, "2010", characteristicUuidValue);
+    surfaces_[static_cast<size_t>(Surface::Essential)] =
+        service_->getCharacteristic(characteristicUuidValue);
+    if (surfaces_[static_cast<size_t>(Surface::Essential)] == nullptr)
+        surfaces_[static_cast<size_t>(Surface::Essential)] =
             service_->createCharacteristic(
                 characteristicUuidValue,
                 NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::NOTIFY,
@@ -931,6 +945,15 @@ void Server::dispatchRequest(const QueueMessage& message) {
         return;
     }
 
+    if (operation == "sensor.read" &&
+        String(document["path"] | "") == "essential.live") {
+        const String essential =
+            config_.snapshotHandler(Surface::Essential, config_.context);
+        sendStage(message.connectionHandle, id, "completed", true, "", "",
+                  essential, currentStateName(), currentStateName());
+        return;
+    }
+
     if (operation == "wifi.status") {
         const String status =
             config_.snapshotHandler(Surface::Connectivity, config_.context);
@@ -1373,6 +1396,7 @@ bool Server::streamSurfaceFor(const String& path, Surface& surface) const {
     const int separator = category.indexOf('.');
     if (separator >= 0) category = category.substring(0, separator);
     if (category == "state") surface = Surface::State;
+    else if (category == "essential") surface = Surface::Essential;
     else if (category == "button") surface = Surface::Button;
     else if (category == "encoder") surface = Surface::Encoder;
     else if (category == "imu") surface = Surface::Imu;
@@ -1798,6 +1822,7 @@ String Server::protocolInfoJson(bool compact) const {
         document["maxMtu"] = 512;
         document["maxMessageBytes"] = MAX_MESSAGE_BYTES;
         document["stateHeartbeatMs"] = 1000;
+        document["essentialState"] = "2010";
         document["otaResumeTtlMs"] = 60000;
         document["streamHeaderBytes"] = STREAM_HEADER_BYTES;
     }

--- a/Software/lib/RadBLE/src/RadBle.h
+++ b/Software/lib/RadBLE/src/RadBle.h
@@ -32,6 +32,7 @@ bool persistDeviceName(const String& name);
 
 enum class Surface : uint8_t {
     State,
+    Essential,
     Button,
     Encoder,
     Imu,

--- a/Software/src/services/communication/rad_ble.cpp
+++ b/Software/src/services/communication/rad_ble.cpp
@@ -36,6 +36,8 @@ constexpr uint16_t RWST = RWS | radble::RESOURCE_STREAMABLE;
 constexpr uint16_t RWP = RW | radble::RESOURCE_PERSISTENT;
 
 const radble::Resource RESOURCES[] = {
+    {"essential", "essential.live", "essential", "object", "", RS,
+     "{\"characteristic\":\"2010\",\"changeDriven\":true,\"maxRateHz\":4}"},
     {"enter", "button.enter", "button", "bool", "", R,
      "{\"events\":[\"click\",\"double\",\"long\"]}"},
     {"encoder", "encoder.main", "encoder", "int", "ticks", RWT,
@@ -566,6 +568,23 @@ String snapshot(radble::Surface surface, void*) {
             if (deserializeJson(current, ossm->getCurrentState()))
                 return R"({"state":"unknown"})";
             document["state"] = current["state"] | "unknown";
+            break;
+        }
+        case radble::Surface::Essential: {
+            JsonDocument current;
+            if (deserializeJson(current, ossm->getCurrentState()))
+                document["state"] = "unknown";
+            else
+                document["state"] = current["state"] | "unknown";
+            document["powered"] = true;
+            document["batteryPercent"] = nullptr;
+            document["charging"] = nullptr;
+            document["positionMm"] =
+                stepper == nullptr ? 0.0f
+                                   : static_cast<float>(stepper->getCurrentPosition()) /
+                                         static_cast<float>(1_mm);
+            document["sessionDistanceMeters"] = session.distanceMeters;
+            document["sessionStrokeCount"] = session.strokeCount;
             break;
         }
         case radble::Surface::Button:


### PR DESCRIPTION
## Summary

- add a common read/notify Essential Live State characteristic (`2010`) and `essential.live` catalog resource
- expose common state/power fields plus DTT game telemetry, RADR connection count, LKBX lock/break countdowns, and OSSM session motion totals
- add shared RadApp types, web auto-subscription, native monitoring, protocol documentation, and contract coverage

## Verification

- development firmware builds: OSSM, LKBX, DTT, RADR
- OSSM native tests: 208 passed
- DTT native tests: 13 passed
- RADR native tests: 8 passed
- LKBX break timing tests: 15 passed
- RadApp protocol typecheck and web typecheck
- RAD BLE web contract tests: 10 passed
- Motion Lab macOS signed build and focused BLE automation round-trip test

Hardware upload and live BLE/serial validation were not performed in this pass because the configured Motion Lab safety workflow requires a camera frame before device interaction, and no camera is present.

<!-- rad-bundle:start -->
Cross-repository bundle: `AJ/BLEEssentialTelemetry`

- [rad-app #1643](https://github.com/researchanddesire/rad-app/pull/1643)
- [ossm #310](https://github.com/KinkyMakers/OSSM-hardware/pull/310)
- [lkbx #497](https://github.com/researchanddesire/Lockbox/pull/497)
- [dtt #213](https://github.com/researchanddesire/DT_Trainer/pull/213)
- [radr #115](https://github.com/researchanddesire/radr-wireless-remote/pull/115)
<!-- rad-bundle:end -->
