### PR TITLE
Retry transient firmware release allocation failures

### DIFF
--- a/.github/workflows/publish_firmware.yml
+++ b/.github/workflows/publish_firmware.yml
@@ -93,6 +93,9 @@ jobs:
           SOURCE_VERSION="$(python scripts/release_version.py read --header Software/src/constants/Version.h)"
           BUMP_TYPE="$(python scripts/release_version.py bump-type --title "$PR_TITLE")"
           RESPONSE="$(curl --fail --silent --show-error \
+            --retry 5 \
+            --retry-delay 2 \
+            --retry-max-time 60 \
             --header "Authorization: Bearer $FIRMWARE_PUBLISH_TOKEN" \
             --header "Content-Type: application/json" \
             --data "$(jq -n \


### PR DESCRIPTION
## Summary

- retry transient version-allocation failures in each firmware publisher
- return explicit retry guidance from the firmware version API
- cover the retryable API response with a focused route test

## Verification

- firmware workflow YAML parses successfully in OSSM, LKBX, DTT, and RADR
- targeted firmware next-version route tests pass (5 tests)
- changed TypeScript files pass Prettier validation

Merging to staging intentionally exercises each immutable firmware candidate workflow.

<!-- rad-bundle:start -->
Cross-repository bundle: `AJ/firmware-release-retry`

- [rad-app #1663](https://github.com/researchanddesire/rad-app/pull/1663)
- [ossm #317](https://github.com/KinkyMakers/OSSM-hardware/pull/317)
- [lkbx #504](https://github.com/researchanddesire/Lockbox/pull/504)
- [dtt #220](https://github.com/researchanddesire/DT_Trainer/pull/220)
- [radr #122](https://github.com/researchanddesire/radr-wireless-remote/pull/122)
<!-- rad-bundle:end -->
