### PR TITLE
Honor BLE speed override in simple penetration

### DIFF
--- a/Software/src/ossm/simple_penetration/simple_penetration.cpp
+++ b/Software/src/ossm/simple_penetration/simple_penetration.cpp
@@ -47,8 +47,12 @@ static void startSimplePenetrationTask(void *pvParameters) {
             settings.speed, Config::Driver::maxSpeedMmPerSecond,
             Config::Advanced::accelerationScaling, (1_mm));
 
+        // Use the effective speed after PlayControls has applied either the
+        // physical knob or the BLE override. Checking the raw knob here makes
+        // a valid BLE speed command unable to start motion when the knob is at
+        // zero, even when speedKnobAsLimit is disabled.
         bool isSpeedZero = simple_pen_logic::isInDeadZone(
-            settings.speedKnob, Config::Advanced::commandDeadZonePercentage);
+            settings.speed, Config::Advanced::commandDeadZonePercentage);
         bool isSpeedChanged =
             !isSpeedZero && simple_pen_logic::isSpeedChangeSignificant(
                                 lastSpeed, speed,


### PR DESCRIPTION
## Summary

- use the effective speed after control overrides are applied
- allow a valid BLE speed command to start motion when the physical knob is zero and knob limiting is disabled

## Status

- current shared-branch work published for staging visibility
- additional hardware validation may still be required

<!-- rad-bundle:start -->
Cross-repository bundle: `AJ/healthy-fumadocs-sync`

- [ossm #318](https://github.com/KinkyMakers/OSSM-hardware/pull/318)
<!-- rad-bundle:end -->
