### PR TITLE
Homing optimization

### DIFF
--- a/Software/src/ossm/homing/homing.cpp
+++ b/Software/src/ossm/homing/homing.cpp
@@ -29,7 +29,7 @@ void clearHoming() {
 
     // Set acceleration and deceleration in steps/s^2
     stepper->setAcceleration(1000_mm);
-    // Set speed in steps/s
+    // Set speed in steps/s, this speed is also used to calculate homing timeout
     stepper->setSpeedInHz(25_mm);
 
     // Clear the stored values.
@@ -57,7 +57,7 @@ static void startHomingTask(void *pvParameters) {
     stepper->setDirectionPin(Pins::Driver::motorDirectionPin, false);
     int16_t sign = stateMachine->is("homing.backward"_s) ? 1 : -1;
 
-    // Set target position as 50mm beyond the maximum stroke length to ensure hitting the hard stop.
+    // Set target position as 50mm+ max stroke length to ensure hitting the endstop.
     int32_t targetPositionInSteps =
         round(sign * (50_mm + Config::Driver::maxStrokeSteps));
 
@@ -77,11 +77,13 @@ static void startHomingTask(void *pvParameters) {
         // Calculate the time in ticks that the task has been running.
         TickType_t xTicksPassed = xCurrentTickCount - xTaskStartTime;
 
-        // If you need the time in milliseconds, convert ticks to milliseconds.
+        // Calculate the number of milliseconds that have passed since the task started.
         // 'portTICK_PERIOD_MS' is the number of milliseconds per tick.
         uint32_t msPassed = xTicksPassed * portTICK_PERIOD_MS;
+        // Calculate the timeout for homing based on the maximum stroke steps + 5s
+        uint32_t msTimeoutHoming = (Config::Driver::maxStrokeSteps / 25_mm + 5) * 1000;
 
-        if (homing_logic::isHomingTimedOut(msPassed, 40000)) {
+        if (msPassed > msTimeoutHoming) {
             ESP_LOGE("Homing", "Homing took too long. Check power and restart");
             errorState.message = ui::strings::homingTookTooLong;
 

--- a/Software/src/ossm/homing/homing.cpp
+++ b/Software/src/ossm/homing/homing.cpp
@@ -57,8 +57,9 @@ static void startHomingTask(void *pvParameters) {
     stepper->setDirectionPin(Pins::Driver::motorDirectionPin, false);
     int16_t sign = stateMachine->is("homing.backward"_s) ? 1 : -1;
 
+    // Set target position as 50mm beyond the maximum stroke length to ensure hitting the hard stop.
     int32_t targetPositionInSteps =
-        round(sign * Config::Driver::maxStrokeSteps);
+        round(sign * (50_mm + Config::Driver::maxStrokeSteps));
 
     ESP_LOGD("Homing", "Target position in steps: %d", targetPositionInSteps);
     stepper->moveTo(targetPositionInSteps, false);

--- a/Software/src/ossm/stroke_engine/stroke_engine.cpp
+++ b/Software/src/ossm/stroke_engine/stroke_engine.cpp
@@ -24,8 +24,8 @@ static void startStrokeEngineTask(void *pvParameters) {
     float measuredStrokeMm = calibration.measuredStrokeSteps / (1_mm);
 
     machineGeometry strokingMachine = {
-        .physicalTravel = abs(calibration.measuredStrokeSteps / (1_mm)),
-        .keepoutBoundary = 6.0};
+        .physicalTravel = abs(measuredStrokeMm),
+        .keepoutBoundary = 0.0}; // KeepoutBoundary controlled outside of StrokeEngine
     SettingPercents lastSetting = settings;
 
     // Adopt the StrokeEngine origin only when entering right after a real
@@ -33,9 +33,8 @@ static void startStrokeEngineTask(void *pvParameters) {
     // position (counter ~0). On a go:menu re-entry neither holds, so we
     // preserve the existing counter and skip the re-base that used to
     // accumulate ~6 mm of drift per entry.
-    constexpr int32_t HOME_TOL = 40;  // steps (~2 mm at 20 steps/mm)
     bool atHome = calibration.justHomed &&
-                  (abs(stepper->getCurrentPosition()) < HOME_TOL);
+                  (abs(stepper->getCurrentPosition()) < 2_mm);
     calibration.justHomed = false;
 
     if (atHome) {

--- a/Software/src/ossm/stroke_engine/stroke_engine.cpp
+++ b/Software/src/ossm/stroke_engine/stroke_engine.cpp
@@ -25,6 +25,7 @@ static void startStrokeEngineTask(void *pvParameters) {
 
     machineGeometry strokingMachine = {
         .physicalTravel = abs(measuredStrokeMm),
+        // keepoutBoundary must match with stepperTranslateFrame in stepper.cpp
         .keepoutBoundary = 0.0}; // KeepoutBoundary controlled outside of StrokeEngine
     SettingPercents lastSetting = settings;
 

--- a/Software/src/services/stepper.cpp
+++ b/Software/src/services/stepper.cpp
@@ -11,9 +11,9 @@ void stepperTranslateFrame(StepperFrame to) {
     if (stepperFrame == to) return;
     if (stepper == nullptr) return;
     // Mirror map between the two frames. The keepout must match
-    // strokingMachine.keepoutBoundary (6 mm) in stroke_engine.cpp.
+    // strokingMachine.keepoutBoundary (0 mm) in stroke_engine.cpp.
     constexpr int32_t keepoutSteps =
-        static_cast<int32_t>(6.0f * Config::Driver::stepsPerMM);
+        static_cast<int32_t>(0.0f * Config::Driver::stepsPerMM);
     stepper->setCurrentPosition(
         -(stepper->getCurrentPosition() + keepoutSteps));
     stepperFrame = to;


### PR DESCRIPTION
A few optimizations for homing.

1. Increase homing target by 50mm. This is to ensure that the machine will hit its endstop if its currently located at the opposite endstop.
2. Calculate homing timeout based on maxStrokeSteps from config.h (+ 5 seconds). So that we don't need an an extremely high timeout for the ones that have a 1m rail. Cuts down homing timeout to 15s for the standard 350mm rail build
In my personal build I have homingSpeed in config.h. I thought about adding it but did not want to decide that myself so left it out
3. Changed StrokeEngine keepoutBoundary to 0.0 because buffert to endstops are managed outside of StrokeEngine (config.h homingOffsetMn). This means we were losing 12mm of our precious travel distance
I considered removing keepoutSteps from stepper.cpp but decided to leave it for compatibility, maybe remove in the future, or consider adding strokeEngineKeepoutBoundary to config.h (almost missed to change in stepper.cpp)
4. Home tolerance calculated in src/ossm/stroke_engine/stroke_engine.cpp will now take in to account step/mm configured in config.h