### PR TITLE
Publish merged OSSM web installer artifacts

### DIFF
--- a/.github/scripts/build_web_installer.py
+++ b/.github/scripts/build_web_installer.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Build and validate the merged 16 MiB OSSM browser-flashing image."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+FLASH_CAPACITY = 16 * 1024 * 1024
+COMPONENT_OFFSETS = {
+    "bootloader.bin": 0x1000,
+    "partitions.bin": 0x8000,
+    "boot_app0.bin": 0xE000,
+    "firmware.bin": 0x10000,
+}
+ESP32_CHIP_ID = 0
+FLASH_MODE_ID = 2
+FLASH_SIZE_ID = 4
+FLASH_FREQUENCY_ID = 0
+
+
+def require_image(path: Path, label: str) -> Path:
+    if not path.is_file() or path.stat().st_size == 0:
+        raise RuntimeError(f"{label} image is missing or empty: {path}")
+    return path
+
+
+def find_platformio_package_file(
+    package: str, relative_path: str, label: str
+) -> Path:
+    platformio_home = Path(
+        os.environ.get("PLATFORMIO_HOME_DIR", Path.home() / ".platformio")
+    )
+    active_package = platformio_home / "packages" / package / relative_path
+    if active_package.is_file():
+        return require_image(active_package, label)
+
+    candidates = sorted(platformio_home.glob(f"packages/{package}@*/{relative_path}"))
+    if len(candidates) != 1:
+        raise RuntimeError(
+            f"expected one PlatformIO {label} file, found {len(candidates)}"
+        )
+    return require_image(candidates[0], label)
+
+
+def find_boot_app0() -> Path:
+    return find_platformio_package_file(
+        "framework-arduinoespressif32",
+        "tools/partitions/boot_app0.bin",
+        "boot_app0",
+    )
+
+
+def find_esptool() -> Path:
+    return find_platformio_package_file("tool-esptoolpy", "esptool.py", "esptool")
+
+
+def validate_esp_image(path: Path, label: str) -> None:
+    content = require_image(path, label).read_bytes()
+    if len(content) < 14 or content[0] != 0xE9:
+        raise RuntimeError(f"{label} does not contain an ESP image header: {path}")
+    chip_id = int.from_bytes(content[12:14], "little")
+    if chip_id != ESP32_CHIP_ID:
+        raise RuntimeError(
+            f"{label} targets chip ID {chip_id}, expected {ESP32_CHIP_ID}"
+        )
+
+
+def build_components(
+    build_dir: Path, boot_app0: Path
+) -> list[tuple[int, Path]]:
+    bootloader = require_image(build_dir / "bootloader.bin", "bootloader")
+    application = require_image(build_dir / "firmware.bin", "application")
+    validate_esp_image(bootloader, "bootloader")
+    validate_esp_image(application, "application")
+
+    bootloader_header = bootloader.read_bytes()[:4]
+    flash_mode_id = bootloader_header[2]
+    flash_size_id = bootloader_header[3] >> 4
+    flash_frequency_id = bootloader_header[3] & 0xF
+    if (
+        flash_mode_id != FLASH_MODE_ID
+        or flash_size_id != FLASH_SIZE_ID
+        or flash_frequency_id != FLASH_FREQUENCY_ID
+    ):
+        raise RuntimeError(
+            "bootloader flash header does not match OSSM's 16 MiB profile: "
+            f"found mode/size/frequency IDs {flash_mode_id}/{flash_size_id}/"
+            f"{flash_frequency_id}, expected {FLASH_MODE_ID}/{FLASH_SIZE_ID}/"
+            f"{FLASH_FREQUENCY_ID}"
+        )
+
+    components = [
+        (
+            COMPONENT_OFFSETS["bootloader.bin"],
+            bootloader,
+        ),
+        (
+            COMPONENT_OFFSETS["partitions.bin"],
+            require_image(build_dir / "partitions.bin", "partition table"),
+        ),
+        (
+            COMPONENT_OFFSETS["boot_app0.bin"],
+            require_image(boot_app0, "boot_app0"),
+        ),
+        (
+            COMPONENT_OFFSETS["firmware.bin"],
+            application,
+        ),
+    ]
+    for index, (offset, path) in enumerate(components):
+        end = offset + path.stat().st_size
+        if end > FLASH_CAPACITY:
+            raise RuntimeError(f"{path} exceeds the physical flash capacity")
+        if index + 1 < len(components) and end > components[index + 1][0]:
+            raise RuntimeError(f"{path} overlaps the next flash component")
+    return components
+
+
+def merge_command(
+    esptool: Path, output: Path, components: list[tuple[int, Path]]
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(esptool),
+        "--chip",
+        "esp32",
+        "merge_bin",
+        "--output",
+        str(output),
+        "--flash_mode",
+        "keep",
+        "--flash_freq",
+        "keep",
+        "--flash_size",
+        "16MB",
+    ]
+    for offset, path in components:
+        command.extend((hex(offset), str(path)))
+    return command
+
+
+def validate_merged_image(
+    output: Path, components: list[tuple[int, Path]]
+) -> None:
+    content = require_image(output, "merged web installer").read_bytes()
+    if len(content) > FLASH_CAPACITY:
+        raise RuntimeError(
+            f"merged image is {len(content)} bytes, beyond 16 MiB flash"
+        )
+    for offset in (COMPONENT_OFFSETS["bootloader.bin"], 0x10000):
+        if offset >= len(content) or content[offset] != 0xE9:
+            raise RuntimeError(f"ESP image magic is missing at {hex(offset)}")
+        chip_id = int.from_bytes(content[offset + 12 : offset + 14], "little")
+        if chip_id != ESP32_CHIP_ID:
+            raise RuntimeError(
+                f"ESP chip ID {chip_id} at {hex(offset)} does not match "
+                f"ESP32 ({ESP32_CHIP_ID})"
+            )
+
+    header = content[
+        COMPONENT_OFFSETS["bootloader.bin"] : COMPONENT_OFFSETS["bootloader.bin"] + 4
+    ]
+    if (
+        header[2] != FLASH_MODE_ID
+        or header[3] >> 4 != FLASH_SIZE_ID
+        or header[3] & 0xF != FLASH_FREQUENCY_ID
+    ):
+        raise RuntimeError("merged bootloader flash header does not match OSSM's profile")
+
+    for offset, source_path in components:
+        source = source_path.read_bytes()
+        merged = content[offset : offset + len(source)]
+        if offset == COMPONENT_OFFSETS["bootloader.bin"]:
+            # esptool may rewrite flash mode/frequency/size bytes 2-3.
+            matches = merged[:2] == source[:2] and merged[4:] == source[4:]
+        else:
+            matches = merged == source
+        if not matches:
+            raise RuntimeError(f"merged component mismatch at {hex(offset)}")
+
+
+def build(build_dir: Path, output: Path, boot_app0: Path | None = None) -> None:
+    components = build_components(build_dir, boot_app0 or find_boot_app0())
+    output.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(merge_command(find_esptool(), output, components), check=True)
+    validate_merged_image(output, components)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build-dir", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--boot-app0", type=Path)
+    args = parser.parse_args()
+    try:
+        build(args.build_dir, args.output, args.boot_app0)
+        print(f"Built validated web installer: {args.output}")
+        return 0
+    except Exception as error:
+        print(f"Web installer build failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/publish_immutable_firmware.py
+++ b/.github/scripts/publish_immutable_firmware.py
@@ -21,7 +21,13 @@ PROJECT_REFS = {
     "main": "acjajruwevyyatztbkdf",
     "staging": "meuaxbjzqrszxdvmacug",
 }
-VALID_ROLES = {"application", "filesystem", "bootloader", "partitions"}
+VALID_ROLES = {
+    "application",
+    "filesystem",
+    "bootloader",
+    "partitions",
+    "web-installer",
+}
 
 
 @dataclass(frozen=True)
@@ -154,6 +160,41 @@ def validation_payload(release_id: str, layer: str, status: str, args: argparse.
     return payload
 
 
+def select_release_artifacts(
+    artifacts: list[Artifact],
+) -> tuple[list[Artifact], list[Artifact]]:
+    if len({artifact.filename for artifact in artifacts}) != len(artifacts):
+        raise RuntimeError("artifact filenames must be unique")
+    if len({artifact.install_order for artifact in artifacts}) != len(artifacts):
+        raise RuntimeError("artifact install orders must be unique")
+    installable = sorted(
+        (artifact for artifact in artifacts if artifact.installable),
+        key=lambda artifact: artifact.install_order,
+    )
+    applications = [
+        artifact for artifact in installable if artifact.role == "application"
+    ]
+    if len(applications) != 1:
+        raise RuntimeError("exactly one installable application artifact is required")
+    web_installers = [
+        artifact for artifact in artifacts if artifact.role == "web-installer"
+    ]
+    if len(web_installers) != 1 or any(
+        artifact.installable for artifact in web_installers
+    ):
+        raise RuntimeError(
+            "exactly one non-installable web-installer artifact is required"
+        )
+    if any(
+        artifact.role not in {"application", "filesystem"}
+        for artifact in installable
+    ):
+        raise RuntimeError("only application and filesystem may be installable")
+    return installable, sorted(
+        [*installable, *web_installers], key=lambda artifact: artifact.install_order
+    )
+
+
 def publish(args: argparse.Namespace) -> str:
     token = os.environ.get("FIRMWARE_PUBLISH_TOKEN", "").strip()
     if not token:
@@ -163,16 +204,7 @@ def publish(args: argparse.Namespace) -> str:
     if not re.fullmatch(r"[0-9a-fA-F]{7,64}", args.build_sha):
         raise RuntimeError("build SHA must contain 7 to 64 hexadecimal characters")
     version = read_version(args.version_file)
-    installable = sorted(
-        (artifact for artifact in args.artifact if artifact.installable),
-        key=lambda artifact: artifact.install_order,
-    )
-    if not any(artifact.role == "application" for artifact in installable):
-        raise RuntimeError("an installable application artifact is required")
-    if len({artifact.filename for artifact in args.artifact}) != len(args.artifact):
-        raise RuntimeError("artifact filenames must be unique")
-    if len({artifact.install_order for artifact in args.artifact}) != len(args.artifact):
-        raise RuntimeError("artifact install orders must be unique")
+    installable, release_artifacts = select_release_artifacts(args.artifact)
 
     metadata = [
         {
@@ -269,10 +301,10 @@ def publish(args: argparse.Namespace) -> str:
                 "publicUrl": uploads_by_name[artifact.filename]["publicUrl"],
                 "sha256": artifact.sha256,
                 "sizeBytes": artifact.size_bytes,
-                "required": True,
+                "required": artifact.installable,
                 "installOrder": artifact.install_order,
             }
-            for artifact in installable
+            for artifact in release_artifacts
         ],
     }
     published = request_json(f"{base_url}/api/internal/firmware/v1/releases", token, release_request)

--- a/.github/scripts/test_build_web_installer.py
+++ b/.github/scripts/test_build_web_installer.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("build_web_installer.py")
+SPEC = importlib.util.spec_from_file_location("build_web_installer", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class BuildWebInstallerTests(unittest.TestCase):
+    def test_merge_preserves_built_mode_and_uses_16_mib_capacity(self):
+        with tempfile.TemporaryDirectory() as directory:
+            command = MODULE.merge_command(
+                Path(directory) / "esptool.py",
+                Path(directory) / "web-installer.bin",
+                [(0x1000, Path(directory) / "bootloader.bin")],
+            )
+        self.assertIn("keep", command)
+        self.assertIn("16MB", command)
+        self.assertEqual(MODULE.FLASH_CAPACITY, 16 * 1024 * 1024)
+
+    def test_rejects_the_wrong_chip_or_flash_header(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bootloader = root / "bootloader.bin"
+            application = root / "firmware.bin"
+            partitions = root / "partitions.bin"
+            boot_app0 = root / "boot_app0.bin"
+            bootloader.write_bytes(b"\xe9\x01\x02\x40" + b"\0" * 10)
+            application.write_bytes(b"\xe9\x01\x00\x00" + b"\0" * 10)
+            partitions.write_bytes(b"partitions")
+            boot_app0.write_bytes(b"boot-app")
+            MODULE.build_components(root, boot_app0)
+
+            bootloader.write_bytes(b"\xe9\x01\x00\x20" + b"\0" * 10)
+            with self.assertRaisesRegex(RuntimeError, "flash header"):
+                MODULE.build_components(root, boot_app0)
+
+            application.write_bytes(
+                b"\xe9\x01\x00\x00" + b"\0" * 8 + b"\x09\x00"
+            )
+            bootloader.write_bytes(b"\xe9\x01\x02\x40" + b"\0" * 10)
+            with self.assertRaisesRegex(RuntimeError, "chip ID"):
+                MODULE.build_components(root, boot_app0)
+
+    def test_validation_checks_magic_and_exact_components(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            components = []
+            bootloader = bytearray(16)
+            bootloader[0] = 0xE9
+            bootloader[1] = 1
+            bootloader[2] = MODULE.FLASH_MODE_ID
+            bootloader[3] = (
+                MODULE.FLASH_SIZE_ID << 4
+            ) | MODULE.FLASH_FREQUENCY_ID
+            bootloader[12:14] = MODULE.ESP32_CHIP_ID.to_bytes(2, "little")
+            application = bytearray(16)
+            application[0] = 0xE9
+            application[1] = 1
+            application[12:14] = MODULE.ESP32_CHIP_ID.to_bytes(2, "little")
+            for offset, name, body in (
+                (0x1000, "bootloader.bin", bytes(bootloader)),
+                (0x8000, "partitions.bin", b"partition-table"),
+                (0xE000, "boot_app0.bin", b"boot-app"),
+                (0x10000, "firmware.bin", bytes(application)),
+            ):
+                path = root / name
+                path.write_bytes(body)
+                components.append((offset, path))
+
+            merged = bytearray(b"\xff" * 0x10020)
+            for offset, path in components:
+                body = path.read_bytes()
+                merged[offset : offset + len(body)] = body
+            output = root / "web-installer.bin"
+            output.write_bytes(merged)
+            MODULE.validate_merged_image(output, components)
+
+            merged[0x10000] = 0
+            output.write_bytes(merged)
+            with self.assertRaisesRegex(RuntimeError, "magic"):
+                MODULE.validate_merged_image(output, components)
+
+            merged[0x10000] = 0xE9
+            merged[0x8000] = 0
+            output.write_bytes(merged)
+            with self.assertRaisesRegex(RuntimeError, "component mismatch"):
+                MODULE.validate_merged_image(output, components)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_publish_immutable_firmware.py
+++ b/.github/scripts/test_publish_immutable_firmware.py
@@ -4,10 +4,12 @@ import unittest
 from pathlib import Path
 
 from publish_immutable_firmware import (
+    Artifact,
     compatibility_rules,
     parse_artifact,
     positive_int,
     read_version,
+    select_release_artifacts,
 )
 
 
@@ -41,6 +43,49 @@ class PublisherTests(unittest.TestCase):
     def test_rejects_non_positive_flash_size(self):
         with self.assertRaises(argparse.ArgumentTypeError):
             positive_int("0")
+
+    def test_web_installer_is_published_but_not_installable(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            firmware = root / "firmware.bin"
+            installer = root / "web-installer.bin"
+            firmware.write_bytes(b"firmware")
+            installer.write_bytes(b"installer")
+            installable, published = select_release_artifacts(
+                [
+                    Artifact("application", firmware, 1, True),
+                    Artifact("web-installer", installer, 4, False),
+                ]
+            )
+        self.assertEqual([artifact.role for artifact in installable], ["application"])
+        self.assertEqual(
+            [artifact.role for artifact in published],
+            ["application", "web-installer"],
+        )
+
+    def test_rejects_installable_web_installer(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            firmware = root / "firmware.bin"
+            installer = root / "web-installer.bin"
+            firmware.write_bytes(b"firmware")
+            installer.write_bytes(b"installer")
+            with self.assertRaisesRegex(RuntimeError, "non-installable"):
+                select_release_artifacts(
+                    [
+                        Artifact("application", firmware, 1, True),
+                        Artifact("web-installer", installer, 4, True),
+                    ]
+                )
+
+    def test_requires_one_web_installer(self):
+        with tempfile.TemporaryDirectory() as directory:
+            firmware = Path(directory) / "firmware.bin"
+            firmware.write_bytes(b"firmware")
+            with self.assertRaisesRegex(RuntimeError, "exactly one"):
+                select_release_artifacts(
+                    [Artifact("application", firmware, 1, True)]
+                )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/publish_firmware.yml
+++ b/.github/workflows/publish_firmware.yml
@@ -11,6 +11,8 @@ on:
       - ".github/scripts/test_download_verified_release.py"
       - ".github/scripts/publish_immutable_firmware.py"
       - ".github/scripts/test_publish_immutable_firmware.py"
+      - ".github/scripts/build_web_installer.py"
+      - ".github/scripts/test_build_web_installer.py"
       - ".github/scripts/release_workflow.py"
       - ".github/scripts/test_release_workflow.py"
       - ".github/workflows/finalize_release.yml"
@@ -139,6 +141,7 @@ jobs:
       - name: Test publisher
         run: |
           python .github/scripts/test_download_verified_release.py
+          python .github/scripts/test_build_web_installer.py
           python .github/scripts/test_publish_immutable_firmware.py
           python .github/scripts/test_release_workflow.py
 
@@ -156,6 +159,12 @@ jobs:
         working-directory: Software
         run: pio run -e "$PIO_ENV"
 
+      - name: Build merged web installer
+        run: |
+          python .github/scripts/build_web_installer.py \
+            --build-dir "Software/.pio/build/$PIO_ENV" \
+            --output "Software/.pio/build/$PIO_ENV/web-installer.bin"
+
       - name: Publish validating release
         id: publish
         run: |
@@ -167,7 +176,8 @@ jobs:
             --min-flash-size-bytes 16777216 \
             --artifact "application:Software/.pio/build/$PIO_ENV/firmware.bin:1:true" \
             --artifact "bootloader:Software/.pio/build/$PIO_ENV/bootloader.bin:2:false" \
-            --artifact "partitions:Software/.pio/build/$PIO_ENV/partitions.bin:3:false"
+            --artifact "partitions:Software/.pio/build/$PIO_ENV/partitions.bin:3:false" \
+            --artifact "web-installer:Software/.pio/build/$PIO_ENV/web-installer.bin:4:false"
 
       - name: Candidate summary
         run: |

--- a/.github/workflows/pull_request_action.yml
+++ b/.github/workflows/pull_request_action.yml
@@ -56,9 +56,18 @@ jobs:
           pio run -e staging
           pio run -e production
 
+      - name: Build merged web installers
+        run: |
+          for environment in staging production; do
+            python .github/scripts/build_web_installer.py \
+              --build-dir "Software/.pio/build/$environment" \
+              --output "Software/.pio/build/$environment/web-installer.bin"
+          done
+
       - name: Test immutable publisher
         run: |
           python .github/scripts/test_download_verified_release.py
+          python .github/scripts/test_build_web_installer.py
           python .github/scripts/test_publish_immutable_firmware.py
           python .github/scripts/test_release_workflow.py
 
@@ -70,6 +79,7 @@ jobs:
             Software/.pio/build/production/firmware.bin
             Software/.pio/build/production/partitions.bin
             Software/.pio/build/production/bootloader.bin
+            Software/.pio/build/production/web-installer.bin
           retention-days: 1
 
   check:
@@ -127,3 +137,15 @@ jobs:
         run: |
           cd Software
           pio test -e test
+
+  check_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify legacy documentation remains retired
+        run: |
+          if [[ -d Documentation ]]; then
+            echo "The retired in-repository documentation workspace was restored"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- build a validated merged ESP32 16 MB browser-flashing image from PlatformIO outputs
- publish exactly one optional `web-installer` artifact while keeping OTA application-only
- validate chip ID, DIO/40 MHz/16 MB flash headers, component bounds, and exact merged component bytes
- exercise the builder in both publish and pull-request workflows

## Why

The browser flasher needs the complete bootable image, while OSSM OTA must continue installing only the application. A separate non-installable web-installer artifact provides the factory image without changing update-task behavior.

## Validation

- builder tests: 3 passed
- publisher tests: 8 passed
- existing publisher, download, and release workflow tests passed
- PlatformIO native tests: 19 suites passed
- staging and production firmware builds passed
- real staging and production merged-image validation passed
- workflow YAML parse, Python compile, and `git diff --check`

No release channels or hardware gates were changed.

## Related rollout PRs

- [RAD Dashboard #1788](https://github.com/researchanddesire/rad-app/pull/1788)
- [DTT #232](https://github.com/researchanddesire/DT_Trainer/pull/232)
- [Lockbox #505](https://github.com/researchanddesire/Lockbox/pull/505)
- [RADR #123](https://github.com/researchanddesire/radr-wireless-remote/pull/123)
- [OSSM #321](https://github.com/KinkyMakers/OSSM-hardware/pull/321)
