### PR TITLE
Fix OSSM upload release kind

### DIFF
--- a/.github/scripts/publish_immutable_firmware.py
+++ b/.github/scripts/publish_immutable_firmware.py
@@ -195,6 +195,33 @@ def select_release_artifacts(
     )
 
 
+def upload_request_payload(
+    args: argparse.Namespace, version: str, artifacts: list[Artifact]
+) -> dict[str, Any]:
+    return {
+        "track": args.track,
+        "deviceType": args.device_type,
+        "version": version,
+        "buildSha": args.build_sha,
+        "kind": args.kind,
+        "storageProjectRef": PROJECT_REFS[args.track],
+        "bucketId": f"{args.device_type}-firmware",
+        "artifacts": [
+            {
+                "role": artifact.role,
+                "filename": artifact.filename,
+                "sha256": artifact.sha256,
+                "sizeBytes": artifact.size_bytes,
+                "installOrder": artifact.install_order,
+                "contentType": "application/json"
+                if artifact.path.suffix == ".json"
+                else "application/octet-stream",
+            }
+            for artifact in artifacts
+        ],
+    }
+
+
 def publish(args: argparse.Namespace) -> str:
     token = os.environ.get("FIRMWARE_PUBLISH_TOKEN", "").strip()
     if not token:
@@ -251,25 +278,7 @@ def publish(args: argparse.Namespace) -> str:
         Artifact("release", release_path, max(item.install_order for item in args.artifact) + 2, False),
     ]
     all_artifacts = [*args.artifact, *generated]
-    upload_request = {
-        "track": args.track,
-        "deviceType": args.device_type,
-        "version": version,
-        "buildSha": args.build_sha,
-        "storageProjectRef": PROJECT_REFS[args.track],
-        "bucketId": f"{args.device_type}-firmware",
-        "artifacts": [
-            {
-                "role": artifact.role,
-                "filename": artifact.filename,
-                "sha256": artifact.sha256,
-                "sizeBytes": artifact.size_bytes,
-                "installOrder": artifact.install_order,
-                "contentType": "application/json" if artifact.path.suffix == ".json" else "application/octet-stream",
-            }
-            for artifact in all_artifacts
-        ],
-    }
+    upload_request = upload_request_payload(args, version, all_artifacts)
     base_url = os.environ.get("FIRMWARE_CONTROL_PLANE_BASE_URL", CONTROL_PLANE).rstrip("/")
     upload_base_url = os.environ.get(
         "FIRMWARE_UPLOAD_BASE_URL",

--- a/.github/scripts/test_publish_immutable_firmware.py
+++ b/.github/scripts/test_publish_immutable_firmware.py
@@ -10,6 +10,7 @@ from publish_immutable_firmware import (
     positive_int,
     read_version,
     select_release_artifacts,
+    upload_request_payload,
 )
 
 
@@ -43,6 +44,22 @@ class PublisherTests(unittest.TestCase):
     def test_rejects_non_positive_flash_size(self):
         with self.assertRaises(argparse.ArgumentTypeError):
             positive_int("0")
+
+    def test_upload_request_includes_release_kind(self):
+        with tempfile.TemporaryDirectory() as directory:
+            firmware = Path(directory) / "firmware.bin"
+            firmware.write_bytes(b"firmware")
+            payload = upload_request_payload(
+                argparse.Namespace(
+                    track="staging",
+                    device_type="ossm",
+                    build_sha="abcdef0",
+                    kind="firmware",
+                ),
+                "1.2.3",
+                [Artifact("application", firmware, 1, True)],
+            )
+        self.assertEqual(payload["kind"], "firmware")
 
     def test_web_installer_is_published_but_not_installable(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
Repairs the staging firmware publication failure after #321.

The upload-signing request now includes the release kind required by the control-plane schema. The payload construction is isolated and directly covered by a regression test.

Checks run locally:
- `python .github/scripts/test_publish_immutable_firmware.py`
- `python .github/scripts/test_release_workflow.py`
- Python compile check
- `git diff --check`