### PR TITLE
Add signed firmware provenance

### DIFF
--- a/.github/scripts/download_verified_release.py
+++ b/.github/scripts/download_verified_release.py
@@ -4,10 +4,13 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import json
 import os
 import re
+import subprocess
+import tempfile
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -15,6 +18,78 @@ from typing import Any
 
 CONTROL_PLANE = "https://dashboard.researchanddesire.com"
 REQUIRED_GATES = {"build", "unit", "integration", "artifact", "hardware"}
+PROVENANCE_KEYS = {
+    "rd-fw-staging-2026-08-01": ("staging", """-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYb/VGPjyRATcddhxhnNs6IZYPSVM
+7GKJFcCpnZgNEYj4z7N897PnOo/KMfyhE5xny9Kl5nJDxEDw0P12xkj75w==
+-----END PUBLIC KEY-----
+"""),
+    "rd-fw-production-2026-08-01": ("main", """-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaXWHINx1VmUw0eMf5xCX5T5w24IZ
+9K31OGTOy/s37oE7lbPyJanjrVq2u4DOqGLWc6YgSTwekFKO8VXq+GW9Cw==
+-----END PUBLIC KEY-----
+"""),
+}
+
+
+def decode_base64url(value: str) -> bytes:
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", value):
+        raise RuntimeError("provenance contains malformed base64url")
+    return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+
+
+def p1363_to_der(signature: bytes) -> bytes:
+    if len(signature) != 64:
+        raise RuntimeError("provenance signature must be 64 bytes")
+    encoded = []
+    for integer in (signature[:32], signature[32:]):
+        integer = integer.lstrip(b"\0") or b"\0"
+        if integer[0] & 0x80:
+            integer = b"\0" + integer
+        encoded.append(b"\x02" + bytes([len(integer)]) + integer)
+    body = b"".join(encoded)
+    return b"\x30" + bytes([len(body)]) + body
+
+
+def verify_provenance(token: str, track: str) -> dict[str, Any]:
+    parts = token.split(".")
+    if len(parts) != 3 or not all(parts):
+        raise RuntimeError("release provenance is not a compact JWS")
+    header = json.loads(decode_base64url(parts[0]))
+    claims = json.loads(decode_base64url(parts[1]))
+    key = PROVENANCE_KEYS.get(header.get("kid"))
+    if (header.get("alg"), header.get("typ")) != ("ES256", "rad-fw-prov+jws"):
+        raise RuntimeError("release provenance has an unsupported header")
+    if key is None or key[0] != track or claims.get("track") != track:
+        raise RuntimeError("release provenance key does not match the track")
+    with tempfile.TemporaryDirectory(prefix="rad-fw-verify-") as directory:
+        directory_path = Path(directory)
+        public_path = directory_path / "public.pem"
+        signature_path = directory_path / "signature.der"
+        public_path.write_text(key[1], encoding="utf-8")
+        signature_path.write_bytes(p1363_to_der(decode_base64url(parts[2])))
+        result = subprocess.run(
+            ["openssl", "dgst", "-sha256", "-verify", str(public_path),
+             "-signature", str(signature_path)],
+            input=f"{parts[0]}.{parts[1]}".encode(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    if result.returncode != 0:
+        raise RuntimeError("release provenance signature is invalid")
+    return claims
+
+
+def runtime_image_sha256(content: bytes) -> str:
+    if len(content) < 56 or content[0] != 0xE9:
+        raise RuntimeError("application is not an ESP app image")
+    if content[23] != 1:
+        return hashlib.sha256(content).hexdigest()
+    expected = content[-32:]
+    if hashlib.sha256(content[:-32]).digest() != expected:
+        raise RuntimeError("application has an invalid appended image digest")
+    return expected.hex()
 
 
 def legacy_version_document(
@@ -74,9 +149,22 @@ def download_release(release_id: str, track: str, device: str, output: Path) -> 
     manifest = json.loads(manifest_bytes)
     if manifest.get("track") != track or manifest.get("deviceType") != device or manifest.get("buildSha") != build_sha:
         raise RuntimeError("manifest identity does not match the release")
+    provenance = status.get("provenance") or {}
+    provenance_token = provenance.get("compact_jws", "")
+    claims = verify_provenance(provenance_token, track)
+    if (
+        claims.get("schema") != "rad.firmware.provenance.v1"
+        or claims.get("issuer") != "research-and-desire"
+        or claims.get("deviceType") != device
+        or claims.get("version") != status.get("version")
+        or claims.get("buildSha") != build_sha
+        or claims.get("manifestSha256") != hashlib.sha256(manifest_bytes).hexdigest()
+    ):
+        raise RuntimeError("provenance claims do not match the release")
     output.mkdir(parents=True, exist_ok=True)
     (output / "manifest.json").write_bytes(manifest_bytes)
     object_base = manifest_url.rsplit("/", 1)[0]
+    saw_application = False
     for artifact in manifest.get("artifacts", []):
         filename = artifact.get("filename", "")
         if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", filename):
@@ -86,7 +174,20 @@ def download_release(release_id: str, track: str, device: str, output: Path) -> 
             raise RuntimeError(f"size mismatch for {filename}")
         if hashlib.sha256(content).hexdigest() != artifact.get("sha256"):
             raise RuntimeError(f"SHA-256 mismatch for {filename}")
+        if artifact.get("role") == "application":
+            saw_application = True
+            if (
+                claims.get("applicationSha256") != artifact.get("sha256")
+                or claims.get("applicationSizeBytes") != len(content)
+                or claims.get("runtimeImageSha256") != runtime_image_sha256(content)
+            ):
+                raise RuntimeError("application does not match its provenance claims")
         (output / filename).write_bytes(content)
+    if not saw_application:
+        raise RuntimeError("manifest has no application artifact")
+    (output / "provenance.json").write_text(
+        json.dumps({"provenance": provenance_token}, separators=(",", ":")) + "\n"
+    )
     (output / "version.json").write_text(
         json.dumps(
             legacy_version_document(status["version"], build_sha, release_id),

--- a/.github/scripts/firmware_provenance_test_vector.json
+++ b/.github/scripts/firmware_provenance_test_vector.json
@@ -1,0 +1,21 @@
+{
+  "description": "Non-secret fixed ES256 vector shared across publisher, control-plane, and firmware tests.",
+  "keyId": "rd-fw-staging-2026-08-01",
+  "publicKeyFingerprintSha256": "35fb9c22de8d69e3a1bb999c69f110b53b4879cd884af10b92cc137013b1c2cc",
+  "claims": {
+    "schema": "rad.firmware.provenance.v1",
+    "issuer": "research-and-desire",
+    "track": "staging",
+    "deviceType": "ossm",
+    "hardwareVariant": "default",
+    "kind": "firmware",
+    "version": "9.8.7",
+    "buildSha": "0123456789abcdef0123456789abcdef01234567",
+    "manifestSha256": "1111111111111111111111111111111111111111111111111111111111111111",
+    "applicationSha256": "2222222222222222222222222222222222222222222222222222222222222222",
+    "runtimeImageSha256": "3333333333333333333333333333333333333333333333333333333333333333",
+    "applicationSizeBytes": 123456,
+    "issuedAt": "2026-08-17T00:00:00Z"
+  },
+  "compactJws": "eyJhbGciOiJFUzI1NiIsImtpZCI6InJkLWZ3LXN0YWdpbmctMjAyNi0wOC0wMSIsInR5cCI6InJhZC1mdy1wcm92K2p3cyJ9.eyJhcHBsaWNhdGlvblNoYTI1NiI6IjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIiLCJhcHBsaWNhdGlvblNpemVCeXRlcyI6MTIzNDU2LCJidWlsZFNoYSI6IjAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVmMDEyMzQ1NjciLCJkZXZpY2VUeXBlIjoib3NzbSIsImhhcmR3YXJlVmFyaWFudCI6ImRlZmF1bHQiLCJpc3N1ZWRBdCI6IjIwMjYtMDgtMTdUMDA6MDA6MDBaIiwiaXNzdWVyIjoicmVzZWFyY2gtYW5kLWRlc2lyZSIsImtpbmQiOiJmaXJtd2FyZSIsIm1hbmlmZXN0U2hhMjU2IjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMSIsInJ1bnRpbWVJbWFnZVNoYTI1NiI6IjMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMiLCJzY2hlbWEiOiJyYWQuZmlybXdhcmUucHJvdmVuYW5jZS52MSIsInRyYWNrIjoic3RhZ2luZyIsInZlcnNpb24iOiI5LjguNyJ9.A4g5XsBzMzZNftjRTKR79HcnkTWYlL_FEV7hZ6hF4k_Pls3BaLa7SN-J1wjuMdKlmdEUWDF4PUqaUwQP1nxm5g"
+}

--- a/.github/scripts/publish_immutable_firmware.py
+++ b/.github/scripts/publish_immutable_firmware.py
@@ -4,10 +4,13 @@
 from __future__ import annotations
 
 import argparse
+import base64
+from datetime import datetime, timezone
 import hashlib
 import json
 import os
 import re
+import subprocess
 import sys
 import time
 import urllib.error
@@ -27,6 +30,10 @@ VALID_ROLES = {
     "bootloader",
     "partitions",
     "web-installer",
+}
+PROVENANCE_KEYS = {
+    "staging": ("rd-fw-staging-2026-08-01", "35fb9c22de8d69e3a1bb999c69f110b53b4879cd884af10b92cc137013b1c2cc"),
+    "main": ("rd-fw-production-2026-08-01", "13f51408cd35f7925d9405e1b04d4e6ebdb57d2149f0eae522caaf3fc4d3aed6"),
 }
 
 
@@ -93,6 +100,108 @@ def compatibility_rules(min_flash_size_bytes: int | None) -> list[dict[str, int]
 
 def json_bytes(value: Any) -> bytes:
     return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def base64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def read_der_length(value: bytes, offset: int) -> tuple[int, int]:
+    length = value[offset]
+    if length < 0x80:
+        return length, offset + 1
+    count = length & 0x7F
+    if count == 0 or count > 2:
+        raise RuntimeError("unsupported ECDSA DER length")
+    return int.from_bytes(value[offset + 1 : offset + 1 + count], "big"), offset + 1 + count
+
+
+def der_ecdsa_to_p1363(signature: bytes) -> bytes:
+    if not signature or signature[0] != 0x30:
+        raise RuntimeError("invalid ECDSA signature encoding")
+    sequence_length, offset = read_der_length(signature, 1)
+    if offset + sequence_length != len(signature):
+        raise RuntimeError("invalid ECDSA signature length")
+    values: list[bytes] = []
+    for _ in range(2):
+        if offset >= len(signature) or signature[offset] != 0x02:
+            raise RuntimeError("invalid ECDSA signature integer")
+        integer_length, offset = read_der_length(signature, offset + 1)
+        integer = signature[offset : offset + integer_length]
+        offset += integer_length
+        integer = integer.lstrip(b"\x00")
+        if len(integer) > 32:
+            raise RuntimeError("ECDSA signature integer is too large")
+        values.append(integer.rjust(32, b"\x00"))
+    return b"".join(values)
+
+
+def sign_provenance(track: str, claims: dict[str, Any]) -> str:
+    private_key = os.environ.get("FIRMWARE_PROVENANCE_SIGNING_KEY_PEM", "").strip()
+    if not private_key:
+        raise RuntimeError("FIRMWARE_PROVENANCE_SIGNING_KEY_PEM is required")
+    key_id, expected_fingerprint = PROVENANCE_KEYS[track]
+    public_der = subprocess.run(
+        ["openssl", "pkey", "-pubout", "-outform", "DER"],
+        input=private_key.encode(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    ).stdout
+    if hashlib.sha256(public_der).hexdigest() != expected_fingerprint:
+        raise RuntimeError("firmware provenance signing key does not match the selected track")
+    header = {"alg": "ES256", "kid": key_id, "typ": "rad-fw-prov+jws"}
+    signing_input = (
+        f"{base64url(json.dumps(header, sort_keys=True, separators=(',', ':')).encode())}."
+        f"{base64url(json.dumps(claims, sort_keys=True, separators=(',', ':')).encode())}"
+    )
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", prefix="rad-fw-key-", delete=True) as key_file:
+        os.chmod(key_file.name, 0o600)
+        key_file.write(private_key)
+        key_file.flush()
+        signature = subprocess.run(
+            ["openssl", "dgst", "-sha256", "-sign", key_file.name],
+            input=signing_input.encode(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        ).stdout
+    return f"{signing_input}.{base64url(der_ecdsa_to_p1363(signature))}"
+
+
+def runtime_image_sha256(application: Artifact) -> str:
+    content = application.content
+    if len(content) < 56 or content[0] != 0xE9:
+        raise RuntimeError("application is not an ESP app image")
+    if content[23] != 1:
+        return hashlib.sha256(content).hexdigest()
+    expected = content[-32:]
+    if hashlib.sha256(content[:-32]).digest() != expected:
+        raise RuntimeError("application has an invalid appended image digest")
+    return expected.hex()
+
+
+def create_provenance(args: argparse.Namespace, version: str, manifest: Artifact, application: Artifact, path: Path, order: int) -> tuple[Artifact, str]:
+    claims = {
+        "schema": "rad.firmware.provenance.v1",
+        "issuer": "research-and-desire",
+        "track": args.track,
+        "deviceType": args.device_type,
+        "hardwareVariant": getattr(args, "hardware_variant", "default"),
+        "kind": args.kind,
+        "version": version,
+        "buildSha": args.build_sha,
+        "manifestSha256": manifest.sha256,
+        "applicationSha256": application.sha256,
+        "runtimeImageSha256": runtime_image_sha256(application),
+        "applicationSizeBytes": application.size_bytes,
+        "issuedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    token = sign_provenance(args.track, claims)
+    path.write_bytes(json_bytes({"provenance": token}))
+    return Artifact("provenance", path, order, False), token
 
 
 def request_json(url: str, token: str, payload: dict[str, Any]) -> dict[str, Any]:
@@ -273,10 +382,16 @@ def publish(args: argparse.Namespace) -> str:
             }
         )
     )
-    generated = [
-        Artifact("manifest", manifest_path, max(item.install_order for item in args.artifact) + 1, False),
-        Artifact("release", release_path, max(item.install_order for item in args.artifact) + 2, False),
-    ]
+    generated_order = max(item.install_order for item in args.artifact)
+    manifest_artifact = Artifact("manifest", manifest_path, generated_order + 1, False)
+    release_artifact = Artifact("release", release_path, generated_order + 2, False)
+    application = next(item for item in installable if item.role == "application")
+    provenance_artifact, provenance_token = create_provenance(
+        args, version, manifest_artifact, application,
+        generated_dir / "provenance.json", generated_order + 3,
+    )
+    generated = [manifest_artifact, release_artifact, provenance_artifact]
+    release_artifacts = [*release_artifacts, provenance_artifact]
     all_artifacts = [*args.artifact, *generated]
     upload_request = upload_request_payload(args, version, all_artifacts)
     base_url = os.environ.get("FIRMWARE_CONTROL_PLANE_BASE_URL", CONTROL_PLANE).rstrip("/")
@@ -303,6 +418,7 @@ def publish(args: argparse.Namespace) -> str:
         "bucketId": f"{args.device_type}-firmware",
         "objectPrefix": signed["objectPrefix"],
         "compatibilityRules": compatibility_rules(args.min_flash_size_bytes),
+        "provenance": provenance_token,
         "artifacts": [
             {
                 "role": artifact.role,

--- a/.github/scripts/test_firmware_provenance.py
+++ b/.github/scripts/test_firmware_provenance.py
@@ -1,0 +1,106 @@
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import download_verified_release as downloader
+import publish_immutable_firmware as publisher
+
+
+FIXTURE = json.loads(
+    (Path(__file__).with_name("firmware_provenance_test_vector.json")).read_text()
+)
+
+
+class FirmwareProvenanceTests(unittest.TestCase):
+    def test_shared_vector_verifies(self):
+        claims = downloader.verify_provenance(FIXTURE["compactJws"], "staging")
+        self.assertEqual(claims, FIXTURE["claims"])
+
+    def test_staging_vector_is_not_valid_for_production(self):
+        with self.assertRaisesRegex(RuntimeError, "does not match the track"):
+            downloader.verify_provenance(FIXTURE["compactJws"], "main")
+
+    def test_malformed_and_truncated_signatures_fail(self):
+        with self.assertRaises(RuntimeError):
+            downloader.verify_provenance("!" + FIXTURE["compactJws"], "staging")
+        with self.assertRaises(RuntimeError):
+            downloader.verify_provenance(FIXTURE["compactJws"][:-20], "staging")
+
+    def test_signing_secret_is_required(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(RuntimeError, "is required"):
+                publisher.sign_provenance("staging", FIXTURE["claims"])
+
+    def test_wrong_signing_key_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            key_path = Path(directory) / "wrong.pem"
+            subprocess.run(
+                [
+                    "openssl",
+                    "genpkey",
+                    "-algorithm",
+                    "EC",
+                    "-pkeyopt",
+                    "ec_paramgen_curve:P-256",
+                    "-out",
+                    str(key_path),
+                ],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            with mock.patch.dict(
+                os.environ,
+                {"FIRMWARE_PROVENANCE_SIGNING_KEY_PEM": key_path.read_text()},
+                clear=True,
+            ):
+                with self.assertRaisesRegex(RuntimeError, "does not match"):
+                    publisher.sign_provenance("staging", FIXTURE["claims"])
+
+    def test_runtime_hash_uses_validated_appended_digest(self):
+        image = bytearray(64)
+        image[0] = 0xE9
+        image[23] = 1
+        import hashlib
+
+        image.extend(hashlib.sha256(image).digest())
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "firmware.bin"
+            path.write_bytes(image)
+            artifact = publisher.Artifact("application", path, 0, True)
+            self.assertEqual(
+                publisher.runtime_image_sha256(artifact),
+                image[-32:].hex(),
+            )
+            image[-1] ^= 1
+            path.write_bytes(image)
+            with self.assertRaisesRegex(RuntimeError, "invalid appended"):
+                publisher.runtime_image_sha256(artifact)
+
+    def test_hardware_root_of_trust_features_remain_disabled(self):
+        repository = Path(__file__).resolve().parents[2]
+        configuration_paths = list(repository.rglob("platformio.ini"))
+        configuration_paths.extend(repository.rglob("sdkconfig*"))
+        configuration_paths = [
+            path
+            for path in configuration_paths
+            if ".pio" not in path.parts and path.is_file()
+        ]
+        combined = "\n".join(
+            path.read_text(errors="replace") for path in configuration_paths
+        )
+        forbidden = (
+            "CONFIG_SECURE_BOOT=y",
+            "CONFIG_SECURE_SIGNED_APPS_NO_SECURE_BOOT=y",
+            "CONFIG_FLASH_ENCRYPTION_ENABLED=y",
+        )
+        for setting in forbidden:
+            self.assertNotIn(setting, combined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/publish_firmware.yml
+++ b/.github/workflows/publish_firmware.yml
@@ -57,6 +57,7 @@ jobs:
       name: ${{ github.ref_name == 'main' && 'firmware-production' || 'firmware-staging' }}
     env:
       FIRMWARE_PUBLISH_TOKEN: ${{ secrets.FIRMWARE_PUBLISH_TOKEN }}
+      FIRMWARE_PROVENANCE_SIGNING_KEY_PEM: ${{ secrets.FIRMWARE_PROVENANCE_SIGNING_KEY_PEM }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -142,6 +143,7 @@ jobs:
         run: |
           python .github/scripts/test_download_verified_release.py
           python .github/scripts/test_build_web_installer.py
+          python .github/scripts/test_firmware_provenance.py
           python .github/scripts/test_publish_immutable_firmware.py
           python .github/scripts/test_release_workflow.py
 

--- a/Software/lib/FirmwareUpdateProtocol/src/FirmwareProvenance.h
+++ b/Software/lib/FirmwareUpdateProtocol/src/FirmwareProvenance.h
@@ -1,0 +1,358 @@
+#pragma once
+
+#include "FirmwareUpdateProtocol.h"
+
+#if defined(ARDUINO_ARCH_ESP32)
+
+#include <Preferences.h>
+#include <esp_ota_ops.h>
+#include <mbedtls/pk.h>
+#include <mbedtls/sha256.h>
+
+#include <array>
+#include <cstring>
+#include <vector>
+
+namespace firmware::provenance {
+
+constexpr const char *STAGING_KEY_ID = "rd-fw-staging-2026-08-01";
+constexpr const char *PRODUCTION_KEY_ID = "rd-fw-production-2026-08-01";
+constexpr const char *STAGING_PUBLIC_KEY = R"KEY(-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYb/VGPjyRATcddhxhnNs6IZYPSVM
+7GKJFcCpnZgNEYj4z7N897PnOo/KMfyhE5xny9Kl5nJDxEDw0P12xkj75w==
+-----END PUBLIC KEY-----
+)KEY";
+constexpr const char *PRODUCTION_PUBLIC_KEY = R"KEY(-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaXWHINx1VmUw0eMf5xCX5T5w24IZ
+9K31OGTOy/s37oE7lbPyJanjrVq2u4DOqGLWc6YgSTwekFKO8VXq+GW9Cw==
+-----END PUBLIC KEY-----
+)KEY";
+
+struct Claims {
+    std::string keyId;
+    std::string track;
+    std::string deviceType;
+    std::string version;
+    std::string buildSha;
+    std::string kind;
+    std::string applicationSha256;
+    std::uint32_t applicationSizeBytes = 0;
+    std::string runtimeImageSha256;
+};
+
+struct Snapshot {
+    std::string origin = "community";
+    std::string token;
+    std::string provenanceId;
+    std::string keyId;
+    std::string imageSha256;
+    std::string buildSha;
+};
+
+inline bool provenanceBuildIdentifiersMatch(const std::string &left,
+                                            const std::string &right) {
+    if (left.size() < 7 || right.size() < 7 || left.size() > 64 ||
+        right.size() > 64) {
+        return false;
+    }
+    const std::size_t sharedLength = std::min(left.size(), right.size());
+    for (std::size_t index = 0; index < sharedLength; ++index) {
+        const auto leftCharacter = static_cast<unsigned char>(left[index]);
+        const auto rightCharacter = static_cast<unsigned char>(right[index]);
+        if (!std::isxdigit(leftCharacter) || !std::isxdigit(rightCharacter) ||
+            std::tolower(leftCharacter) != std::tolower(rightCharacter)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+inline int base64Value(char value) {
+    if (value >= 'A' && value <= 'Z') return value - 'A';
+    if (value >= 'a' && value <= 'z') return value - 'a' + 26;
+    if (value >= '0' && value <= '9') return value - '0' + 52;
+    if (value == '-' || value == '+') return 62;
+    if (value == '_' || value == '/') return 63;
+    return -1;
+}
+
+inline bool decodeBase64Url(const std::string &input,
+                            std::vector<unsigned char> &output) {
+    output.clear();
+    unsigned int buffer = 0;
+    int bits = 0;
+    for (char character : input) {
+        if (character == '=') break;
+        const int value = base64Value(character);
+        if (value < 0) return false;
+        buffer = (buffer << 6) | static_cast<unsigned int>(value);
+        bits += 6;
+        if (bits >= 8) {
+            bits -= 8;
+            output.push_back(static_cast<unsigned char>((buffer >> bits) & 0xff));
+        }
+    }
+    return !output.empty();
+}
+
+inline void appendDerInteger(std::vector<unsigned char> &output,
+                             const unsigned char *value) {
+    std::size_t start = 0;
+    while (start < 31 && value[start] == 0) ++start;
+    const bool prefixZero = (value[start] & 0x80) != 0;
+    output.push_back(0x02);
+    output.push_back(static_cast<unsigned char>(32 - start + (prefixZero ? 1 : 0)));
+    if (prefixZero) output.push_back(0x00);
+    output.insert(output.end(), value + start, value + 32);
+}
+
+inline bool p1363ToDer(const std::vector<unsigned char> &signature,
+                       std::vector<unsigned char> &der) {
+    if (signature.size() != 64) return false;
+    std::vector<unsigned char> body;
+    appendDerInteger(body, signature.data());
+    appendDerInteger(body, signature.data() + 32);
+    der = {0x30, static_cast<unsigned char>(body.size())};
+    der.insert(der.end(), body.begin(), body.end());
+    return true;
+}
+
+inline std::string tokenId(const std::string &token) {
+    unsigned char digest[32] = {};
+    mbedtls_sha256_ret(reinterpret_cast<const unsigned char *>(token.data()),
+                       token.size(), digest, 0);
+    std::vector<unsigned char> value(digest, digest + sizeof(digest));
+    static constexpr char ALPHABET[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    std::string output;
+    unsigned int buffer = 0;
+    int bits = 0;
+    for (unsigned char byte : value) {
+        buffer = (buffer << 8) | byte;
+        bits += 8;
+        while (bits >= 6) {
+            bits -= 6;
+            output.push_back(ALPHABET[(buffer >> bits) & 0x3f]);
+        }
+    }
+    if (bits > 0) output.push_back(ALPHABET[(buffer << (6 - bits)) & 0x3f]);
+    return output;
+}
+
+inline bool verifyToken(const std::string &token, const DeviceReport &expected,
+                        Claims &claims) {
+    const auto first = token.find('.');
+    const auto second = first == std::string::npos
+                            ? std::string::npos
+                            : token.find('.', first + 1);
+    if (first == std::string::npos || second == std::string::npos ||
+        token.find('.', second + 1) != std::string::npos) {
+        return false;
+    }
+    std::vector<unsigned char> headerBytes, payloadBytes, signature, der;
+    if (!decodeBase64Url(token.substr(0, first), headerBytes) ||
+        !decodeBase64Url(token.substr(first + 1, second - first - 1), payloadBytes) ||
+        !decodeBase64Url(token.substr(second + 1), signature) ||
+        !p1363ToDer(signature, der)) {
+        return false;
+    }
+    JsonDocument header;
+    JsonDocument payload;
+    if (deserializeJson(header, headerBytes.data(), headerBytes.size()) ||
+        deserializeJson(payload, payloadBytes.data(), payloadBytes.size())) {
+        return false;
+    }
+    const char *alg = header["alg"] | "";
+    const char *typ = header["typ"] | "";
+    const char *kid = header["kid"] | "";
+    if (std::strcmp(alg, "ES256") != 0 ||
+        std::strcmp(typ, "rad-fw-prov+jws") != 0) {
+        return false;
+    }
+    const char *publicKey = nullptr;
+    const char *keyTrack = nullptr;
+    if (std::strcmp(kid, STAGING_KEY_ID) == 0) {
+        publicKey = STAGING_PUBLIC_KEY;
+        keyTrack = "staging";
+    } else if (std::strcmp(kid, PRODUCTION_KEY_ID) == 0) {
+        publicKey = PRODUCTION_PUBLIC_KEY;
+        keyTrack = "main";
+    } else {
+        return false;
+    }
+    const std::string signingInput = token.substr(0, second);
+    unsigned char digest[32] = {};
+    if (mbedtls_sha256_ret(
+            reinterpret_cast<const unsigned char *>(signingInput.data()),
+            signingInput.size(), digest, 0) != 0) {
+        return false;
+    }
+    mbedtls_pk_context key;
+    mbedtls_pk_init(&key);
+    const int parseResult = mbedtls_pk_parse_public_key(
+        &key, reinterpret_cast<const unsigned char *>(publicKey),
+        std::strlen(publicKey) + 1);
+    const int verifyResult =
+        parseResult == 0
+            ? mbedtls_pk_verify(&key, MBEDTLS_MD_SHA256, digest, sizeof(digest),
+                                der.data(), der.size())
+            : parseResult;
+    mbedtls_pk_free(&key);
+    if (verifyResult != 0) return false;
+
+    const char *schema = payload["schema"] | "";
+    const char *issuer = payload["issuer"] | "";
+    claims.keyId = kid;
+    claims.track = payload["track"] | "";
+    claims.deviceType = payload["deviceType"] | "";
+    claims.version = payload["version"] | "";
+    claims.buildSha = payload["buildSha"] | "";
+    claims.kind = payload["kind"] | "";
+    claims.applicationSha256 = payload["applicationSha256"] | "";
+    claims.applicationSizeBytes = payload["applicationSizeBytes"] | 0;
+    claims.runtimeImageSha256 = payload["runtimeImageSha256"] | "";
+    return std::strcmp(schema, "rad.firmware.provenance.v1") == 0 &&
+           std::strcmp(issuer, "research-and-desire") == 0 &&
+           claims.track == keyTrack && claims.track == expected.reportedTrack &&
+           claims.deviceType == expected.deviceType &&
+           claims.version == expected.currentVersion &&
+           (expected.currentBuild.empty() ||
+            provenanceBuildIdentifiersMatch(claims.buildSha,
+                                            expected.currentBuild)) &&
+           (expected.firmwareHash.empty() ||
+            claims.runtimeImageSha256 == expected.firmwareHash);
+}
+
+inline std::string readStored(const char *key) {
+    Preferences preferences;
+    if (!preferences.begin("fw-prov", true)) return {};
+    const String value = preferences.getString(key, "");
+    preferences.end();
+    return value.c_str();
+}
+
+inline std::string currentToken() { return readStored("current"); }
+inline std::string currentTokenId() {
+    const auto token = currentToken();
+    return token.empty() ? std::string{} : tokenId(token);
+}
+inline std::string currentImageSha256() {
+    const auto token = currentToken();
+    const auto first = token.find('.');
+    const auto second = first == std::string::npos ? std::string::npos
+                                                    : token.find('.', first + 1);
+    if (second == std::string::npos) return {};
+    std::vector<unsigned char> payload;
+    if (!decodeBase64Url(token.substr(first + 1, second - first - 1), payload)) return {};
+    JsonDocument document;
+    if (deserializeJson(document, payload.data(), payload.size())) return {};
+    return std::string(document["runtimeImageSha256"] | "");
+}
+
+inline bool writeStored(const char *key, const std::string &value) {
+    Preferences preferences;
+    if (!preferences.begin("fw-prov", false)) return false;
+    const bool stored = preferences.putString(key, value.c_str()) > 0;
+    preferences.end();
+    return stored;
+}
+
+inline Snapshot snapshot(const DeviceReport &running) {
+    Snapshot result;
+    result.imageSha256 = running.firmwareHash;
+    result.token = readStored("current");
+    Claims claims;
+    if (result.token.empty()) return result;
+    if (!verifyToken(result.token, running, claims)) {
+        result.origin = "invalid";
+        result.provenanceId = tokenId(result.token);
+        return result;
+    }
+    result.origin = "official";
+    result.provenanceId = tokenId(result.token);
+    result.keyId = claims.keyId;
+    result.imageSha256 = claims.runtimeImageSha256;
+    result.buildSha = claims.buildSha;
+    return result;
+}
+
+inline std::string runningImageSha256() {
+    const esp_partition_t *running = esp_ota_get_running_partition();
+    unsigned char digest[32] = {};
+    if (running == nullptr ||
+        esp_partition_get_sha256(running, digest) != ESP_OK) {
+        return {};
+    }
+    static constexpr char HEX_CHARACTERS[] = "0123456789abcdef";
+    std::string output;
+    output.reserve(sizeof(digest) * 2);
+    for (const unsigned char byte : digest) {
+        output.push_back(HEX_CHARACTERS[byte >> 4]);
+        output.push_back(HEX_CHARACTERS[byte & 0x0f]);
+    }
+    return output;
+}
+
+inline Snapshot runningSnapshot(const char *track, const char *deviceType,
+                                const char *version, const char *buildSha) {
+    DeviceReport report;
+    report.reportedTrack = track == nullptr ? "" : track;
+    report.deviceType = deviceType == nullptr ? "" : deviceType;
+    report.currentVersion = version == nullptr ? "" : version;
+    report.currentBuild = buildSha == nullptr ? "" : buildSha;
+    report.firmwareHash = runningImageSha256();
+    return snapshot(report);
+}
+
+inline void reconcile(DeviceReport &running) {
+    const std::string pending = readStored("pending");
+    Claims pendingClaims;
+    if (!pending.empty() && verifyToken(pending, running, pendingClaims)) {
+        writeStored("current", pending);
+        Preferences preferences;
+        if (preferences.begin("fw-prov", false)) {
+            preferences.remove("pending");
+            preferences.end();
+        }
+    }
+    const Snapshot current = snapshot(running);
+    if (!current.token.empty()) running.firmwareProvenance = current.token;
+}
+
+inline void observeCurrent(const DeviceReport &running,
+                           const Decision &decision) {
+    if (decision.currentProvenance.empty()) return;
+    Claims claims;
+    if (verifyToken(decision.currentProvenance, running, claims)) {
+        writeStored("current", decision.currentProvenance);
+    }
+}
+
+inline void stageUpdate(const DeviceReport &running, const Decision &decision) {
+    if (!decision.shouldUpdate || decision.provenance.empty()) return;
+    DeviceReport target = running;
+    target.reportedTrack = decision.assignedTrack;
+    target.currentVersion = decision.nextHopVersion;
+    target.currentBuild = decision.buildSha;
+    std::string applicationSha256;
+    std::uint32_t applicationSizeBytes = 0;
+    for (std::size_t index = 0; index < decision.artifactCount; ++index) {
+        if (decision.artifacts[index].role == "application") {
+            applicationSha256 = decision.artifacts[index].sha256;
+            applicationSizeBytes = decision.artifacts[index].sizeBytes;
+            break;
+        }
+    }
+    target.firmwareHash.clear();
+    Claims claims;
+    if (verifyToken(decision.provenance, target, claims) &&
+        claims.kind == decision.kind &&
+        claims.applicationSha256 == applicationSha256 &&
+        claims.applicationSizeBytes == applicationSizeBytes) {
+        writeStored("pending", decision.provenance);
+    }
+}
+
+}  // namespace firmware::provenance
+
+#endif

--- a/Software/lib/FirmwareUpdateProtocol/src/FirmwareUpdateProtocol.h
+++ b/Software/lib/FirmwareUpdateProtocol/src/FirmwareUpdateProtocol.h
@@ -21,6 +21,8 @@ struct DeviceReport {
     std::string currentVersion;
     std::string currentBuild;
     std::string firmwareHash;
+    int provenanceCapability = 1;
+    std::string firmwareProvenance;
     std::string chip;
     std::uint32_t chipRevision = 0;
     std::uint32_t chipCores = 0;
@@ -51,6 +53,9 @@ struct Decision {
     std::string nextHopVersion;
     std::string releaseId;
     std::string buildSha;
+    std::string firmwareOrigin;
+    std::string currentProvenance;
+    std::string provenance;
     std::string kind;
     std::array<Artifact, MAX_ARTIFACTS> artifacts{};
     std::size_t artifactCount = 0;
@@ -154,6 +159,9 @@ inline std::string serializeReport(const DeviceReport &report) {
         document["currentBuild"] = report.currentBuild;
     if (!report.firmwareHash.empty())
         document["firmwareHash"] = report.firmwareHash;
+    document["provenanceCapability"] = report.provenanceCapability;
+    if (!report.firmwareProvenance.empty())
+        document["firmwareProvenance"] = report.firmwareProvenance;
     if (!report.chip.empty()) document["chip"] = report.chip;
     document["chipRevision"] = report.chipRevision;
     if (report.chipCores > 0) document["chipCores"] = report.chipCores;
@@ -246,6 +254,16 @@ inline bool parseDecision(const std::string &payload,
 
     parsed.trackChanged = document["trackChanged"].as<bool>();
     parsed.nextCheckSeconds = document["nextCheckSeconds"].as<std::uint32_t>();
+    if (!document["firmwareOrigin"].isNull() &&
+        !readRequiredString(document["firmwareOrigin"], parsed.firmwareOrigin)) {
+        error = "invalid firmware origin";
+        return false;
+    }
+    if (!document["currentProvenance"].isNull() &&
+        !readRequiredString(document["currentProvenance"], parsed.currentProvenance)) {
+        error = "invalid current firmware provenance";
+        return false;
+    }
     if (!parsed.shouldUpdate) {
         if (!document["update"].isNull()) {
             error = "no-update response contains update data";
@@ -275,6 +293,11 @@ inline bool parseDecision(const std::string &payload,
         }
     } else if (canonicalResponse) {
         error = "canonical update response is missing build SHA";
+        return false;
+    }
+    if (!update["provenance"].isNull() &&
+        !readRequiredString(update["provenance"], parsed.provenance)) {
+        error = "invalid update firmware provenance";
         return false;
     }
 

--- a/Software/lib/FirmwareUpdateProtocol/src/FirmwareUpdateRuntime.h
+++ b/Software/lib/FirmwareUpdateProtocol/src/FirmwareUpdateRuntime.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "FirmwareUpdateProtocol.h"
+#include "FirmwareProvenance.h"
 
 #if defined(ARDUINO_ARCH_ESP32)
 
@@ -40,6 +41,19 @@ inline bool postCheck(const char *apiBaseUrl, const DeviceReport &report,
     }
     esp_http_client_set_header(client, "Content-Type", "application/json");
     esp_http_client_set_header(client, "Accept-Encoding", "identity");
+    esp_http_client_set_header(client, "X-RAD-Firmware-Provenance-Capability",
+                               "1");
+    if (!report.firmwareProvenance.empty()) {
+        const std::string provenanceId =
+            provenance::tokenId(report.firmwareProvenance);
+        esp_http_client_set_header(client, "X-RAD-Firmware-Provenance",
+                                   report.firmwareProvenance.c_str());
+        esp_http_client_set_header(client, "X-RAD-Firmware-Provenance-ID",
+                                   provenanceId.c_str());
+    }
+    if (!report.firmwareHash.empty())
+        esp_http_client_set_header(client, "X-RAD-Firmware-Image-SHA256",
+                                   report.firmwareHash.c_str());
 
     bool success = false;
     if (esp_http_client_open(client, body.size()) != ESP_OK ||

--- a/Software/src/ossm/OSSM.cpp
+++ b/Software/src/ossm/OSSM.cpp
@@ -1,5 +1,7 @@
 #include "OSSM.h"
 
+#include "FirmwareProvenance.h"
+
 #include "command/commands.hpp"
 #include "ossm/state/ble.h"
 #include "ossm/state/calibration.h"
@@ -164,6 +166,8 @@ String OSSM::getCurrentState() {
     float positionMm = float(stepper->getCurrentPosition()) / float(1_mm);
     if (isnan(positionMm)) positionMm = 0.0f;
 
+    const String provenanceId =
+        firmware::provenance::currentTokenId().c_str();
     return "{\"timestamp\":" + String((unsigned long)millis()) +
            ",\"state\":\"" + currentState +
            "\",\"speed\":" + String((int)settings.speed) +
@@ -173,5 +177,6 @@ String OSSM::getCurrentState() {
            ",\"buffer\":" + String((int)settings.buffer) +
            ",\"pattern\":" + String(static_cast<int>(settings.pattern)) +
            ",\"position\":" + String(positionMm, 2) +
-           ",\"sessionId\":\"" + sessionId + "\"}";
+           ",\"sessionId\":\"" + sessionId +
+           "\",\"firmwareProvenanceId\":\"" + provenanceId + "\"}";
 }

--- a/Software/src/ossm/pages/pairing.cpp
+++ b/Software/src/ossm/pages/pairing.cpp
@@ -5,6 +5,8 @@
 
 #include <ArduinoJson.h>
 
+#include "FirmwareProvenance.h"
+
 #include "constants/Version.h"
 #include "ossm/Events.h"
 #include "ossm/state/state.h"
@@ -30,6 +32,15 @@ static int requestDeviceAuth(bool updatePairingCode) {
     String url = String(RAD_SERVER) + "/api/ossm/auth";
     http.begin(url);
     http.addHeader("Content-Type", "application/json");
+    http.addHeader("X-RAD-Firmware-Provenance-Capability", "1");
+    const auto provenanceToken = firmware::provenance::currentToken();
+    if (!provenanceToken.empty()) {
+        http.addHeader("X-RAD-Firmware-Provenance", provenanceToken.c_str());
+        http.addHeader("X-RAD-Firmware-Provenance-ID",
+                       firmware::provenance::currentTokenId().c_str());
+        http.addHeader("X-RAD-Firmware-Image-SHA256",
+                       firmware::provenance::currentImageSha256().c_str());
+    }
 
     JsonDocument doc;
     doc["mac"] = macAddress;

--- a/Software/src/services/communication/mqtt.cpp
+++ b/Software/src/services/communication/mqtt.cpp
@@ -4,6 +4,8 @@
 #include <esp_log.h>
 #include <utils/getEfuseMac.h>
 #include <utils/random.h>
+#include "FirmwareProvenance.h"
+#include "constants/Version.h"
 
 // Define the global variables here
 bool mqttConnected = false;
@@ -43,6 +45,20 @@ void event_connected_handler(void* handler_args, esp_event_base_t base,
                              int32_t event_id, void* event_data) {
     ESP_LOGD("MQTT", "Connected to MQTT broker");
     mqttConnected = true;
+    const auto token = firmware::provenance::currentToken();
+    JsonDocument document;
+    document["provenanceCapability"] = 1;
+    document["provenance"] = token;
+    document["provenanceId"] = firmware::provenance::currentTokenId();
+    document["imageSha256"] = firmware::provenance::runningImageSha256();
+    document["track"] = FIRMWARE_TRACK;
+    document["version"] = VERSION;
+    document["buildSha"] = FIRMWARE_BUILD_SHA;
+    String payload;
+    serializeJson(document, payload);
+    const String topic = "ossm/" + getMacAddress() + "/firmware";
+    esp_mqtt_client_publish(mqttClient, topic.c_str(), payload.c_str(),
+                            payload.length(), 1, true);
 }
 
 void event_disconnected_handler(void* handler_args, esp_event_base_t base,

--- a/Software/src/services/communication/rad_ble.cpp
+++ b/Software/src/services/communication/rad_ble.cpp
@@ -3,6 +3,7 @@
 #include <Preferences.h>
 #include <WiFi.h>
 
+#include "FirmwareProvenance.h"
 #include "constants/Pins.h"
 #include "constants/UserConfig.h"
 #include "constants/Version.h"
@@ -86,6 +87,8 @@ const radble::Resource RESOURCES[] = {
      RW, "{\"min\":1,\"max\":100}"},
     {"device_name", "device.name", "setting", "string", "", RWP,
      "{\"maxBytes\":24,\"emptyResets\":true}"},
+    {"firmware_provenance", "device.firmwareProvenance", "setting", "object",
+     "", R, ""},
     {"calibration_offset", "motion.currentOffset", "motion", "float", "raw",
      R, ""},
     {"calibration_stroke", "motion.measuredStroke", "motion", "float", "steps",
@@ -190,6 +193,14 @@ radble::Result settingValue(const String& path) {
         preferences.begin("UserConfig", true);
         document["value"] = preferences.getString("DeviceName", "OSSM");
         preferences.end();
+    } else if (path == "device.firmwareProvenance") {
+        const auto snapshot = firmware::provenance::runningSnapshot(
+            FIRMWARE_TRACK, "ossm", VERSION, FIRMWARE_BUILD_SHA);
+        document["origin"] = snapshot.origin;
+        document["keyId"] = snapshot.keyId;
+        document["provenanceId"] = snapshot.provenanceId;
+        document["imageSha256"] = snapshot.imageSha256;
+        document["compactJws"] = snapshot.token;
     }
     else
         return radble::Result::failure("unknown_path", "Unknown setting path");

--- a/Software/src/utils/update.cpp
+++ b/Software/src/utils/update.cpp
@@ -83,6 +83,7 @@ firmware::DeviceReport makeDeviceReport() {
     report.psramSizeBytes = ESP.getPsramSize();
     report.otaSlotSizeBytes = otaSlotSizeBytes();
     report.partitionLayout = currentPartitionLayout();
+    firmware::provenance::reconcile(report);
     return report;
 }
 
@@ -126,6 +127,8 @@ void updateTask(void *pvParameters) {
         finishWithoutUpdate(mqttStopped, error);
         return;
     }
+    firmware::provenance::observeCurrent(report, decision);
+    firmware::provenance::stageUpdate(report, decision);
 
     ESP_LOGW(UPDATE_TAG,
              "Resolver assigned track=%s shouldUpdate=%s target=%s next=%s reason=%s",

--- a/Software/test/test_firmware_update_protocol/test_main.cpp
+++ b/Software/test/test_firmware_update_protocol/test_main.cpp
@@ -14,10 +14,13 @@ const char *VALID_RESPONSE = R"json({
   "reportedTrack": "main",
   "assignedTrack": "staging",
   "trackChanged": true,
+  "firmwareOrigin": "official",
+  "currentProvenance": "current.jws.token",
   "currentVersion": "1.0.34",
   "targetVersion": "1.0.35",
   "nextHopVersion": "1.0.35",
   "update": {
+    "provenance": "target.jws.token",
     "releaseId": "00000000-0000-4000-8000-000000000001",
     "buildSha": "0123456789abcdef0123456789abcdef01234567",
     "kind": "firmware",
@@ -64,6 +67,8 @@ void test_serializes_version_identity_and_hardware_fields() {
         .currentBuild = "0123456789abcdef",
         .firmwareHash =
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        .provenanceCapability = 1,
+        .firmwareProvenance = "current.jws.token",
         .chip = "ESP32-D0WDQ6",
         .chipRevision = 0,
         .chipCores = 2,
@@ -79,6 +84,9 @@ void test_serializes_version_identity_and_hardware_fields() {
     TEST_ASSERT_EQUAL_STRING("ossm", parsed["deviceType"]);
     TEST_ASSERT_EQUAL_STRING("AA:BB:CC:DD:EE:FF", parsed["deviceId"]);
     TEST_ASSERT_EQUAL_STRING("main", parsed["reportedTrack"]);
+    TEST_ASSERT_EQUAL_INT(1, parsed["provenanceCapability"]);
+    TEST_ASSERT_EQUAL_STRING("current.jws.token",
+                             parsed["firmwareProvenance"]);
     TEST_ASSERT_EQUAL_STRING("1.0.34", parsed["currentVersion"]);
     TEST_ASSERT_EQUAL_STRING("0123456789abcdef", parsed["currentBuild"]);
     TEST_ASSERT_EQUAL_STRING(report.firmwareHash.c_str(), parsed["firmwareHash"]);
@@ -108,6 +116,11 @@ void test_parses_canonical_decision_and_orders_artifacts() {
     TEST_ASSERT_EQUAL_INT(1, decision.protocolVersion);
     TEST_ASSERT_EQUAL_STRING("update-available", decision.reason.c_str());
     TEST_ASSERT_EQUAL_STRING("staging", decision.assignedTrack.c_str());
+    TEST_ASSERT_EQUAL_STRING("official", decision.firmwareOrigin.c_str());
+    TEST_ASSERT_EQUAL_STRING("current.jws.token",
+                             decision.currentProvenance.c_str());
+    TEST_ASSERT_EQUAL_STRING("target.jws.token",
+                             decision.provenance.c_str());
     TEST_ASSERT_TRUE(decision.trackChanged);
     TEST_ASSERT_EQUAL_STRING("1.0.35", decision.nextHopVersion.c_str());
     TEST_ASSERT_EQUAL_STRING(


### PR DESCRIPTION
## Summary

- add ES256-signed provenance artifacts to official firmware publishing
- verify release relationships in the control plane and classify device origin without blocking community firmware
- report provenance over update checks, HTTP, MQTT, and the read-only RAD BLE resource
- keep Secure Boot, signed-app enforcement, and flash encryption disabled
- keep factory Build PC builds community-classified and verify official bundles with public keys only

## Verification

- all firmware publisher/provenance Python tests
- native firmware protocol tests for OSSM, LKBX, DTT, and RADR
- staging and production hardware builds, including LKBX PSRAM and DTT migration/provision variants
- web lint, typecheck, complete test suite, focused firmware tests, local Supabase reset/lint, and 65 firmware control-plane SQL assertions
- coordinated workspace transaction/worktree tests

## Rollout

Apply migration 20260817153348 only to staging Supabase project meuaxbjzqrszxdvmacug before activating provenance-required releases. Production remains unchanged.

<!-- rad-bundle:start -->
Cross-repository bundle: `AJ/firmware-provenance`

- [rad-app #1792](https://github.com/researchanddesire/rad-app/pull/1792)
- [ossm #323](https://github.com/KinkyMakers/OSSM-hardware/pull/323)
- [lkbx #506](https://github.com/researchanddesire/Lockbox/pull/506)
- [dtt #233](https://github.com/researchanddesire/DT_Trainer/pull/233)
- [radr #125](https://github.com/researchanddesire/radr-wireless-remote/pull/125)
<!-- rad-bundle:end -->
