### PR TITLE
hotfix pin firmware build dependencies

### DIFF
--- a/Software/platformio.ini
+++ b/Software/platformio.ini
@@ -23,16 +23,16 @@ build_flags =
     -Wno-unknown-pragmas
     -D FIRMWARE_USE_IDF_CRT_BUNDLE
 lib_deps =
-    https://github.com/researchanddesire/rad-ble.git#v1.0.0
+    https://github.com/researchanddesire/rad-ble.git#4af1c5f8cbcd94af651d3d34db65cf6a86966359
     h2zero/NimBLE-Arduino@2.4.0
-    https://github.com/tzapu/WiFiManager.git
-    gin66/FastAccelStepper@^0.30.13
-    bblanchon/ArduinoJson@^7.4.2
-    fastled/FastLED@^3.6.0
-    olikraus/U8g2@^2.35.8
-    ricmoo/QRCode@^0.0.1
-    igorantolic/Ai Esp32 Rotary Encoder @ ^1.6
-    mathertel/OneButton@^2.5.0
+    https://github.com/tzapu/WiFiManager.git#4131fe617d01d746677e8b909379597162c2ca58
+    gin66/FastAccelStepper@0.30.15
+    bblanchon/ArduinoJson@7.4.3
+    fastled/FastLED@3.10.3
+    olikraus/U8g2@2.36.18
+    ricmoo/QRCode@0.0.1
+    igorantolic/Ai Esp32 Rotary Encoder@1.7.0
+    mathertel/OneButton@2.6.2
 upload_speed = 921600
 check_skip_packages = true
 check_tool = clangtidy
@@ -62,7 +62,7 @@ build_flags =
     -D MQTT_USERNAME="\"TEST\""
     -D MQTT_PASSWORD="\"Hello123!\""
 extends = common
-platform = espressif32
+platform = espressif32@6.12.0
 board = esp32dev
 framework = arduino, espidf
 monitor_speed = 115200
@@ -89,7 +89,7 @@ build_flags =
     -D MQTT_USERNAME="\"5k0vjgg9hCwZGAFnmFJg7nTU6sDElr43\""
     -D MQTT_PASSWORD="\"tJDV2u8eGdMBPzHlGKQBnirCrrA9zg5w\""
 extends = common
-platform = espressif32
+platform = espressif32@6.12.0
 board = esp32dev
 framework = arduino, espidf
 monitor_speed = 115200
@@ -114,7 +114,7 @@ build_flags =
     -D MQTT_USERNAME="\"5k0vjgg9hCwZGAFnmFJg7nTU6sDElr43\""
     -D MQTT_PASSWORD="\"tJDV2u8eGdMBPzHlGKQBnirCrrA9zg5w\""
 extends = common
-platform = espressif32
+platform = espressif32@6.12.0
 board = esp32dev
 framework = arduino, espidf
 monitor_speed = 115200
@@ -127,10 +127,10 @@ targets =
 
 [env:test]
 lib_deps =
-    fabiobatsilva/ArduinoFake@^0.4.0
-    bblanchon/ArduinoJson@^7.4.2
-    olikraus/U8g2@^2.35.8
-    ricmoo/QRCode@^0.0.1
+    fabiobatsilva/ArduinoFake@0.4.0
+    bblanchon/ArduinoJson@7.4.3
+    olikraus/U8g2@2.36.18
+    ricmoo/QRCode@0.0.1
 lib_ignore = StrokeEngine
 build_flags =
     -std=gnu++17
@@ -150,4 +150,4 @@ build_src_filter = +<stub.cpp>
 test_ignore = test_hw_*, test_measurements, test_display
 lib_ldf_mode = deep+
 lib_compat_mode = off
-platform = native
+platform = native@1.2.1


### PR DESCRIPTION
## Summary

- pin PlatformIO platforms to exact versions
- replace moving/ranged firmware libraries with exact releases or immutable Git commits
- pin resolver-selected transitive libraries where registry ambiguity remained

## Verification

- OSSM native tests: 208 passed; production build passed
- LKBX native tests: 55 passed; production build passed
- DTT native tests: 17 passed; production-v2 and provision builds passed
- RADR native tests: 8 passed; production build passed with an isolated pioarduino package home

## Existing limitations observed

- LKBX `test_native` / `test_idle` omits the implementation that defines `setNotIdle` and `setNotIdleISR`; the normal native suite passes
- DTT legacy production-v1 is 6,673 bytes over its protected 1.25 MiB OTA slot; the partition table is intentionally unchanged

<!-- rad-bundle:start -->
Cross-repository bundle: `AJ/pin-firmware-dependencies`

- [ossm #328](https://github.com/KinkyMakers/OSSM-hardware/pull/328)
- [lkbx #509](https://github.com/researchanddesire/Lockbox/pull/509)
- [dtt #238](https://github.com/researchanddesire/DT_Trainer/pull/238)
- [radr #131](https://github.com/researchanddesire/radr-wireless-remote/pull/131)
<!-- rad-bundle:end -->
