### PR TITLE
Support 4 MB and 16 MB OSSM firmware

### DIFF
--- a/.github/scripts/build_web_installer.py
+++ b/.github/scripts/build_web_installer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build and validate the merged 16 MiB OSSM browser-flashing image."""
+"""Build and validate a merged OSSM browser-flashing image."""
 
 from __future__ import annotations
 
@@ -7,9 +7,22 @@ import argparse
 import os
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
-FLASH_CAPACITY = 16 * 1024 * 1024
+
+@dataclass(frozen=True)
+class Profile:
+    flash_size: str
+    capacity: int
+    flash_size_id: int
+
+
+PROFILES = {
+    "esp32-4mb": Profile("4MB", 4 * 1024 * 1024, 2),
+    "esp32-16mb": Profile("16MB", 16 * 1024 * 1024, 4),
+}
+
 COMPONENT_OFFSETS = {
     "bootloader.bin": 0x1000,
     "partitions.bin": 0x8000,
@@ -18,7 +31,6 @@ COMPONENT_OFFSETS = {
 }
 ESP32_CHIP_ID = 0
 FLASH_MODE_ID = 2
-FLASH_SIZE_ID = 4
 FLASH_FREQUENCY_ID = 0
 
 
@@ -70,7 +82,7 @@ def validate_esp_image(path: Path, label: str) -> None:
 
 
 def build_components(
-    build_dir: Path, boot_app0: Path
+    profile: Profile, build_dir: Path, boot_app0: Path
 ) -> list[tuple[int, Path]]:
     bootloader = require_image(build_dir / "bootloader.bin", "bootloader")
     application = require_image(build_dir / "firmware.bin", "application")
@@ -83,13 +95,13 @@ def build_components(
     flash_frequency_id = bootloader_header[3] & 0xF
     if (
         flash_mode_id != FLASH_MODE_ID
-        or flash_size_id != FLASH_SIZE_ID
+        or flash_size_id != profile.flash_size_id
         or flash_frequency_id != FLASH_FREQUENCY_ID
     ):
         raise RuntimeError(
-            "bootloader flash header does not match OSSM's 16 MiB profile: "
+            f"bootloader flash header does not match OSSM's {profile.flash_size} profile: "
             f"found mode/size/frequency IDs {flash_mode_id}/{flash_size_id}/"
-            f"{flash_frequency_id}, expected {FLASH_MODE_ID}/{FLASH_SIZE_ID}/"
+            f"{flash_frequency_id}, expected {FLASH_MODE_ID}/{profile.flash_size_id}/"
             f"{FLASH_FREQUENCY_ID}"
         )
 
@@ -113,7 +125,7 @@ def build_components(
     ]
     for index, (offset, path) in enumerate(components):
         end = offset + path.stat().st_size
-        if end > FLASH_CAPACITY:
+        if end > profile.capacity:
             raise RuntimeError(f"{path} exceeds the physical flash capacity")
         if index + 1 < len(components) and end > components[index + 1][0]:
             raise RuntimeError(f"{path} overlaps the next flash component")
@@ -121,7 +133,10 @@ def build_components(
 
 
 def merge_command(
-    esptool: Path, output: Path, components: list[tuple[int, Path]]
+    esptool: Path,
+    profile: Profile,
+    output: Path,
+    components: list[tuple[int, Path]],
 ) -> list[str]:
     command = [
         sys.executable,
@@ -136,7 +151,7 @@ def merge_command(
         "--flash_freq",
         "keep",
         "--flash_size",
-        "16MB",
+        profile.flash_size,
     ]
     for offset, path in components:
         command.extend((hex(offset), str(path)))
@@ -144,12 +159,12 @@ def merge_command(
 
 
 def validate_merged_image(
-    output: Path, components: list[tuple[int, Path]]
+    output: Path, profile: Profile, components: list[tuple[int, Path]]
 ) -> None:
     content = require_image(output, "merged web installer").read_bytes()
-    if len(content) > FLASH_CAPACITY:
+    if len(content) > profile.capacity:
         raise RuntimeError(
-            f"merged image is {len(content)} bytes, beyond 16 MiB flash"
+            f"merged image is {len(content)} bytes, beyond {profile.flash_size} flash"
         )
     for offset in (COMPONENT_OFFSETS["bootloader.bin"], 0x10000):
         if offset >= len(content) or content[offset] != 0xE9:
@@ -166,7 +181,7 @@ def validate_merged_image(
     ]
     if (
         header[2] != FLASH_MODE_ID
-        or header[3] >> 4 != FLASH_SIZE_ID
+        or header[3] >> 4 != profile.flash_size_id
         or header[3] & 0xF != FLASH_FREQUENCY_ID
     ):
         raise RuntimeError("merged bootloader flash header does not match OSSM's profile")
@@ -183,21 +198,32 @@ def validate_merged_image(
             raise RuntimeError(f"merged component mismatch at {hex(offset)}")
 
 
-def build(build_dir: Path, output: Path, boot_app0: Path | None = None) -> None:
-    components = build_components(build_dir, boot_app0 or find_boot_app0())
+def build(
+    profile_name: str,
+    build_dir: Path,
+    output: Path,
+    boot_app0: Path | None = None,
+) -> None:
+    profile = PROFILES[profile_name]
+    boot_app0_path = boot_app0 or find_boot_app0()
+    components = build_components(profile, build_dir, boot_app0_path)
+    (build_dir / "boot_app0.bin").write_bytes(boot_app0_path.read_bytes())
     output.parent.mkdir(parents=True, exist_ok=True)
-    subprocess.run(merge_command(find_esptool(), output, components), check=True)
-    validate_merged_image(output, components)
+    subprocess.run(
+        merge_command(find_esptool(), profile, output, components), check=True
+    )
+    validate_merged_image(output, profile, components)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
+    parser.add_argument("--profile", required=True, choices=tuple(PROFILES))
     parser.add_argument("--build-dir", required=True, type=Path)
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--boot-app0", type=Path)
     args = parser.parse_args()
     try:
-        build(args.build_dir, args.output, args.boot_app0)
+        build(args.profile, args.build_dir, args.output, args.boot_app0)
         print(f"Built validated web installer: {args.output}")
         return 0
     except Exception as error:

--- a/.github/scripts/download_verified_release.py
+++ b/.github/scripts/download_verified_release.py
@@ -125,14 +125,26 @@ def fetch(url: str, token: str | None = None) -> bytes:
         raise RuntimeError(f"download returned HTTP {error.code}: {detail}") from error
 
 
-def download_release(release_id: str, track: str, device: str, output: Path) -> str:
+def download_release(
+    release_id: str,
+    track: str,
+    device: str,
+    hardware_variant: str,
+    output: Path,
+) -> str:
     token = os.environ.get("FIRMWARE_PUBLISH_TOKEN", "").strip()
     if not token:
         raise RuntimeError("FIRMWARE_PUBLISH_TOKEN is required")
     base = os.environ.get("FIRMWARE_CONTROL_PLANE_BASE_URL", CONTROL_PLANE).rstrip("/")
     status = json.loads(fetch(f"{base}/api/internal/firmware/v1/releases/{release_id}?track={track}", token))
-    if status.get("track") != track or status.get("deviceType") != device:
-        raise RuntimeError("release track or device family does not match")
+    if (
+        status.get("track") != track
+        or status.get("deviceType") != device
+        or status.get("hardwareVariant") != hardware_variant
+    ):
+        raise RuntimeError(
+            "release track, device family, or hardware variant does not match"
+        )
     allowed = {"active"} if track == "staging" else {"ready", "active"}
     if status.get("lifecycle") not in allowed:
         raise RuntimeError("release has not passed the required lifecycle gate")
@@ -147,7 +159,12 @@ def download_release(release_id: str, track: str, device: str, output: Path) -> 
     manifest_url = status["manifestUrl"]
     manifest_bytes = fetch(manifest_url)
     manifest = json.loads(manifest_bytes)
-    if manifest.get("track") != track or manifest.get("deviceType") != device or manifest.get("buildSha") != build_sha:
+    if (
+        manifest.get("track") != track
+        or manifest.get("deviceType") != device
+        or manifest.get("hardwareVariant") != hardware_variant
+        or manifest.get("buildSha") != build_sha
+    ):
         raise RuntimeError("manifest identity does not match the release")
     provenance = status.get("provenance") or {}
     provenance_token = provenance.get("compact_jws", "")
@@ -156,6 +173,7 @@ def download_release(release_id: str, track: str, device: str, output: Path) -> 
         claims.get("schema") != "rad.firmware.provenance.v1"
         or claims.get("issuer") != "research-and-desire"
         or claims.get("deviceType") != device
+        or claims.get("hardwareVariant") != hardware_variant
         or claims.get("version") != status.get("version")
         or claims.get("buildSha") != build_sha
         or claims.get("manifestSha256") != hashlib.sha256(manifest_bytes).hexdigest()
@@ -203,9 +221,16 @@ def main() -> int:
     parser.add_argument("--release-id", required=True)
     parser.add_argument("--track", required=True, choices=("main", "staging"))
     parser.add_argument("--device", required=True, choices=("dtt", "lkbx", "ossm", "radr"))
+    parser.add_argument("--hardware-variant", required=True, choices=("v1", "v2"))
     parser.add_argument("--output", required=True, type=Path)
     args = parser.parse_args()
-    version = download_release(args.release_id, args.track, args.device, args.output)
+    version = download_release(
+        args.release_id,
+        args.track,
+        args.device,
+        args.hardware_variant,
+        args.output,
+    )
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:
         with open(github_output, "a", encoding="utf-8") as handle:

--- a/.github/scripts/publish_immutable_firmware.py
+++ b/.github/scripts/publish_immutable_firmware.py
@@ -317,6 +317,7 @@ def upload_request_payload(
     return {
         "track": args.track,
         "deviceType": args.device_type,
+        "hardwareVariant": args.hardware_variant,
         "version": version,
         "buildSha": args.build_sha,
         "kind": args.kind,
@@ -396,6 +397,7 @@ def publish(args: argparse.Namespace) -> str:
             {
                 "protocolVersion": 1,
                 "deviceType": args.device_type,
+                "hardwareVariant": args.hardware_variant,
                 "track": args.track,
                 "version": version,
                 "buildSha": args.build_sha,
@@ -408,6 +410,7 @@ def publish(args: argparse.Namespace) -> str:
             {
                 "protocolVersion": 1,
                 "deviceType": args.device_type,
+                "hardwareVariant": args.hardware_variant,
                 "track": args.track,
                 "version": version,
                 "buildSha": args.build_sha,
@@ -473,6 +476,7 @@ def publish(args: argparse.Namespace) -> str:
     release_request = {
         "track": args.track,
         "deviceType": args.device_type,
+        "hardwareVariant": args.hardware_variant,
         "version": version,
         "buildSha": args.build_sha,
         "kind": args.kind,
@@ -522,6 +526,7 @@ def publish(args: argparse.Namespace) -> str:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--device-type", required=True, choices=("dtt", "lkbx", "ossm", "radr"))
+    parser.add_argument("--hardware-variant", required=True, choices=("v1", "v2"))
     parser.add_argument("--track", required=True, choices=("main", "staging"))
     parser.add_argument("--build-sha", required=True)
     parser.add_argument("--version-file", required=True, type=Path)

--- a/.github/scripts/release_workflow.py
+++ b/.github/scripts/release_workflow.py
@@ -18,13 +18,15 @@ def branch_configuration(branch: str) -> dict[str, str]:
     if branch == "main":
         return {
             "TRACK": "main",
-            "PIO_ENV": "production",
+            "PIO_ENV_V1": "production-v1",
+            "PIO_ENV_V2": "production-v2",
             "STORAGE_PROJECT_REF": PROJECT_REFS["main"],
         }
     if branch == "staging":
         return {
             "TRACK": "staging",
-            "PIO_ENV": "staging",
+            "PIO_ENV_V1": "staging-v1",
+            "PIO_ENV_V2": "staging-v2",
             "STORAGE_PROJECT_REF": PROJECT_REFS["staging"],
         }
     raise ValueError("firmware publication is restricted to main or staging")

--- a/.github/scripts/test_build_web_installer.py
+++ b/.github/scripts/test_build_web_installer.py
@@ -15,16 +15,18 @@ SPEC.loader.exec_module(MODULE)
 
 
 class BuildWebInstallerTests(unittest.TestCase):
-    def test_merge_preserves_built_mode_and_uses_16_mib_capacity(self):
+    def test_merge_preserves_built_mode_and_uses_selected_capacity(self):
         with tempfile.TemporaryDirectory() as directory:
+            profile = MODULE.PROFILES["esp32-4mb"]
             command = MODULE.merge_command(
                 Path(directory) / "esptool.py",
+                profile,
                 Path(directory) / "web-installer.bin",
                 [(0x1000, Path(directory) / "bootloader.bin")],
             )
         self.assertIn("keep", command)
-        self.assertIn("16MB", command)
-        self.assertEqual(MODULE.FLASH_CAPACITY, 16 * 1024 * 1024)
+        self.assertIn("4MB", command)
+        self.assertEqual(profile.capacity, 4 * 1024 * 1024)
 
     def test_rejects_the_wrong_chip_or_flash_header(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -37,18 +39,19 @@ class BuildWebInstallerTests(unittest.TestCase):
             application.write_bytes(b"\xe9\x01\x00\x00" + b"\0" * 10)
             partitions.write_bytes(b"partitions")
             boot_app0.write_bytes(b"boot-app")
-            MODULE.build_components(root, boot_app0)
+            profile = MODULE.PROFILES["esp32-16mb"]
+            MODULE.build_components(profile, root, boot_app0)
 
             bootloader.write_bytes(b"\xe9\x01\x00\x20" + b"\0" * 10)
             with self.assertRaisesRegex(RuntimeError, "flash header"):
-                MODULE.build_components(root, boot_app0)
+                MODULE.build_components(profile, root, boot_app0)
 
             application.write_bytes(
                 b"\xe9\x01\x00\x00" + b"\0" * 8 + b"\x09\x00"
             )
             bootloader.write_bytes(b"\xe9\x01\x02\x40" + b"\0" * 10)
             with self.assertRaisesRegex(RuntimeError, "chip ID"):
-                MODULE.build_components(root, boot_app0)
+                MODULE.build_components(profile, root, boot_app0)
 
     def test_validation_checks_magic_and_exact_components(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -59,7 +62,7 @@ class BuildWebInstallerTests(unittest.TestCase):
             bootloader[1] = 1
             bootloader[2] = MODULE.FLASH_MODE_ID
             bootloader[3] = (
-                MODULE.FLASH_SIZE_ID << 4
+                MODULE.PROFILES["esp32-16mb"].flash_size_id << 4
             ) | MODULE.FLASH_FREQUENCY_ID
             bootloader[12:14] = MODULE.ESP32_CHIP_ID.to_bytes(2, "little")
             application = bytearray(16)
@@ -82,18 +85,19 @@ class BuildWebInstallerTests(unittest.TestCase):
                 merged[offset : offset + len(body)] = body
             output = root / "web-installer.bin"
             output.write_bytes(merged)
-            MODULE.validate_merged_image(output, components)
+            profile = MODULE.PROFILES["esp32-16mb"]
+            MODULE.validate_merged_image(output, profile, components)
 
             merged[0x10000] = 0
             output.write_bytes(merged)
             with self.assertRaisesRegex(RuntimeError, "magic"):
-                MODULE.validate_merged_image(output, components)
+                MODULE.validate_merged_image(output, profile, components)
 
             merged[0x10000] = 0xE9
             merged[0x8000] = 0
             output.write_bytes(merged)
             with self.assertRaisesRegex(RuntimeError, "component mismatch"):
-                MODULE.validate_merged_image(output, components)
+                MODULE.validate_merged_image(output, profile, components)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_publish_immutable_firmware.py
+++ b/.github/scripts/test_publish_immutable_firmware.py
@@ -56,6 +56,7 @@ class PublisherTests(unittest.TestCase):
                 argparse.Namespace(
                     track="staging",
                     device_type="ossm",
+                    hardware_variant="v1",
                     build_sha="abcdef0",
                     kind="firmware",
                 ),
@@ -63,6 +64,7 @@ class PublisherTests(unittest.TestCase):
                 [Artifact("application", firmware, 1, True)],
             )
         self.assertEqual(payload["kind"], "firmware")
+        self.assertEqual(payload["hardwareVariant"], "v1")
 
     def test_web_installer_is_published_but_not_installable(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/.github/scripts/test_release_workflow.py
+++ b/.github/scripts/test_release_workflow.py
@@ -20,8 +20,18 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("github-token: ${{ github.token }}", workflow)
 
     def test_branch_configuration_maps_tracks_and_projects(self):
-        self.assertEqual(branch_configuration("main")["PIO_ENV"], "production")
-        self.assertEqual(branch_configuration("staging")["PIO_ENV"], "staging")
+        self.assertEqual(
+            branch_configuration("main")["PIO_ENV_V1"], "production-v1"
+        )
+        self.assertEqual(
+            branch_configuration("main")["PIO_ENV_V2"], "production-v2"
+        )
+        self.assertEqual(
+            branch_configuration("staging")["PIO_ENV_V1"], "staging-v1"
+        )
+        self.assertEqual(
+            branch_configuration("staging")["PIO_ENV_V2"], "staging-v2"
+        )
         self.assertNotEqual(
             branch_configuration("main")["STORAGE_PROJECT_REF"],
             branch_configuration("staging")["STORAGE_PROJECT_REF"],

--- a/.github/workflows/finalize_release.yml
+++ b/.github/workflows/finalize_release.yml
@@ -7,6 +7,11 @@ on:
         description: Validated control-plane release UUID
         required: true
         type: string
+      hardware_variant:
+        description: OSSM hardware lane
+        required: true
+        type: choice
+        options: [v1, v2]
 
 permissions:
   contents: write
@@ -32,11 +37,12 @@ jobs:
             --header "Authorization: Bearer $FIRMWARE_PUBLISH_TOKEN" \
             "https://dashboard.researchanddesire.com/api/internal/firmware/v1/releases/${{ inputs.release_id }}?track=main" \
             --output release.json
-          jq -e --arg device "ossm" '
+          jq -e --arg device "ossm" --arg variant "${{ inputs.hardware_variant }}" '
             . as $release |
             $release.buildSha as $sha |
             $release.track == "main" and
             $release.deviceType == $device and
+            $release.hardwareVariant == $variant and
             $release.buildSha == $sha and
             $release.lifecycle == "ready" and
             $release.paused == true and

--- a/.github/workflows/publish_firmware.yml
+++ b/.github/workflows/publish_firmware.yml
@@ -157,32 +157,72 @@ jobs:
       - name: Select track build
         run: python .github/scripts/release_workflow.py configure --branch "$GITHUB_REF_NAME"
 
-      - name: Build application
+      - name: Build V1 and V2 applications
         working-directory: Software
-        run: pio run -e "$PIO_ENV"
+        run: |
+          pio run -e "$PIO_ENV_V1" -j 1
+          pio run -e "$PIO_ENV_V2" -j 1
 
-      - name: Build merged web installer
+      - name: Verify each firmware fits its OTA slot
+        run: |
+          V1_SIZE="$(stat --format=%s "Software/.pio/build/$PIO_ENV_V1/firmware.bin")"
+          V2_SIZE="$(stat --format=%s "Software/.pio/build/$PIO_ENV_V2/firmware.bin")"
+          test "$V1_SIZE" -le $((0x1E0000 - 0x4000))
+          test "$V2_SIZE" -le $((0x780000 - 0x4000))
+          echo "V1 firmware: $V1_SIZE bytes" >> "$GITHUB_STEP_SUMMARY"
+          echo "V2 firmware: $V2_SIZE bytes" >> "$GITHUB_STEP_SUMMARY"
+          grep -qx '# CONFIG_BT_ENABLED is not set' "Software/sdkconfig.$PIO_ENV_V1"
+          grep -qx 'CONFIG_BT_ENABLED=y' "Software/sdkconfig.$PIO_ENV_V2"
+          if ~/.platformio/packages/toolchain-xtensa-esp32/bin/xtensa-esp32-elf-nm \
+            "Software/.pio/build/$PIO_ENV_V1/firmware.elf" | \
+            grep -Eq 'NimBLE|initRadBle|radBleServer'; then
+            echo "V1 unexpectedly contains Bluetooth symbols" >&2
+            exit 1
+          fi
+
+      - name: Build merged V1 and V2 web installers
         run: |
           python .github/scripts/build_web_installer.py \
-            --build-dir "Software/.pio/build/$PIO_ENV" \
-            --output "Software/.pio/build/$PIO_ENV/web-installer.bin"
+            --profile esp32-4mb \
+            --build-dir "Software/.pio/build/$PIO_ENV_V1" \
+            --output "Software/.pio/build/$PIO_ENV_V1/web-installer.bin"
+          python .github/scripts/build_web_installer.py \
+            --profile esp32-16mb \
+            --build-dir "Software/.pio/build/$PIO_ENV_V2" \
+            --output "Software/.pio/build/$PIO_ENV_V2/web-installer.bin"
 
-      - name: Publish validating release
-        id: publish
+      - name: Publish validating V1 release
+        id: publish_v1
         run: |
           python .github/scripts/publish_immutable_firmware.py \
             --device-type ossm \
+            --hardware-variant v1 \
+            --track "$TRACK" \
+            --build-sha "$RELEASE_BUILD_SHA" \
+            --version-file Software/src/constants/Version.h \
+            --artifact "application:Software/.pio/build/$PIO_ENV_V1/firmware.bin:1:true" \
+            --artifact "bootloader:Software/.pio/build/$PIO_ENV_V1/bootloader.bin:2:false" \
+            --artifact "partitions:Software/.pio/build/$PIO_ENV_V1/partitions.bin:3:false" \
+            --artifact "web-installer:Software/.pio/build/$PIO_ENV_V1/web-installer.bin:4:false"
+
+      - name: Publish validating V2 release
+        id: publish_v2
+        run: |
+          python .github/scripts/publish_immutable_firmware.py \
+            --device-type ossm \
+            --hardware-variant v2 \
             --track "$TRACK" \
             --build-sha "$RELEASE_BUILD_SHA" \
             --version-file Software/src/constants/Version.h \
             --min-flash-size-bytes 16777216 \
-            --artifact "application:Software/.pio/build/$PIO_ENV/firmware.bin:1:true" \
-            --artifact "bootloader:Software/.pio/build/$PIO_ENV/bootloader.bin:2:false" \
-            --artifact "partitions:Software/.pio/build/$PIO_ENV/partitions.bin:3:false" \
-            --artifact "web-installer:Software/.pio/build/$PIO_ENV/web-installer.bin:4:false"
+            --artifact "application:Software/.pio/build/$PIO_ENV_V2/firmware.bin:1:true" \
+            --artifact "bootloader:Software/.pio/build/$PIO_ENV_V2/bootloader.bin:2:false" \
+            --artifact "partitions:Software/.pio/build/$PIO_ENV_V2/partitions.bin:3:false" \
+            --artifact "web-installer:Software/.pio/build/$PIO_ENV_V2/web-installer.bin:4:false"
 
       - name: Candidate summary
         run: |
-          echo "Release ${{ steps.publish.outputs.release_id }} is waiting for hardware validation" >> "$GITHUB_STEP_SUMMARY"
+          echo "V1 release ${{ steps.publish_v1.outputs.release_id }} is waiting for hardware validation" >> "$GITHUB_STEP_SUMMARY"
+          echo "V2 release ${{ steps.publish_v2.outputs.release_id }} is waiting for hardware validation" >> "$GITHUB_STEP_SUMMARY"
           echo "Version: ${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "Build: ${{ steps.version.outputs.release_build_sha }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pull_request_action.yml
+++ b/.github/workflows/pull_request_action.yml
@@ -53,16 +53,32 @@ jobs:
       - name: Build PlatformIO Project
         run: |
           cd Software
-          pio run -e staging
-          pio run -e production
+          pio run -e staging-v1 -j 1
+          pio run -e staging-v2 -j 1
+          pio run -e production-v1 -j 1
+          pio run -e production-v2 -j 1
 
       - name: Build merged web installers
         run: |
-          for environment in staging production; do
-            python .github/scripts/build_web_installer.py \
-              --build-dir "Software/.pio/build/$environment" \
-              --output "Software/.pio/build/$environment/web-installer.bin"
-          done
+          python .github/scripts/build_web_installer.py \
+            --profile esp32-4mb \
+            --build-dir "Software/.pio/build/production-v1" \
+            --output "Software/.pio/build/production-v1/web-installer.bin"
+          python .github/scripts/build_web_installer.py \
+            --profile esp32-16mb \
+            --build-dir "Software/.pio/build/production-v2" \
+            --output "Software/.pio/build/production-v2/web-installer.bin"
+
+      - name: Verify V1 omits Bluetooth
+        run: |
+          grep -qx '# CONFIG_BT_ENABLED is not set' Software/sdkconfig.production-v1
+          grep -qx 'CONFIG_BT_ENABLED=y' Software/sdkconfig.production-v2
+          if ~/.platformio/packages/toolchain-xtensa-esp32/bin/xtensa-esp32-elf-nm \
+            Software/.pio/build/production-v1/firmware.elf | \
+            grep -Eq 'NimBLE|initRadBle|radBleServer'; then
+            echo "V1 unexpectedly contains Bluetooth symbols" >&2
+            exit 1
+          fi
 
       - name: Test immutable publisher
         run: |
@@ -76,10 +92,14 @@ jobs:
         with:
           name: firmware-bin
           path: |
-            Software/.pio/build/production/firmware.bin
-            Software/.pio/build/production/partitions.bin
-            Software/.pio/build/production/bootloader.bin
-            Software/.pio/build/production/web-installer.bin
+            Software/.pio/build/production-v1/firmware.bin
+            Software/.pio/build/production-v1/partitions.bin
+            Software/.pio/build/production-v1/bootloader.bin
+            Software/.pio/build/production-v1/web-installer.bin
+            Software/.pio/build/production-v2/firmware.bin
+            Software/.pio/build/production-v2/partitions.bin
+            Software/.pio/build/production-v2/bootloader.bin
+            Software/.pio/build/production-v2/web-installer.bin
           retention-days: 1
 
   check:
@@ -108,7 +128,7 @@ jobs:
       - name: Check PlatformIO Project
         run: |
           cd Software
-          pio check --skip-packages --fail-on-defect high -e production -f src
+          pio check --skip-packages --fail-on-defect high -e production-v2 -f src
 
   test:
     needs: check_changes

--- a/.github/workflows/release_alpha.yml
+++ b/.github/workflows/release_alpha.yml
@@ -33,6 +33,7 @@ jobs:
             --release-id "${{ inputs.release_id }}" \
             --track staging \
             --device ossm \
+            --hardware-variant v2 \
             --output firmware
 
       - name: Replace explicit alpha alias

--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -33,6 +33,7 @@ jobs:
             --release-id "${{ inputs.release_id }}" \
             --track main \
             --device ossm \
+            --hardware-variant v2 \
             --output firmware
 
       - name: Replace production Supabase aliases

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,7 @@ PlatformIO ESP32 code/OSSM_ESP32/.vscode/launch.json
 node_modules
 
 scratch/*
+
+# PlatformIO generates hybrid Arduino/ESP-IDF config snapshots per variant.
+Software/sdkconfig.*-v1
+Software/sdkconfig.*-v2

--- a/Software/CLAUDE.md
+++ b/Software/CLAUDE.md
@@ -12,14 +12,16 @@ OSSM (Open Source Sex Machine) is an ESP32-based stepper motor device firmware. 
 - **State Machine:** Boost.SML (header-only, `include/boost/sml.hpp`)
 - **Motor:** FastAccelStepper (stepper motor with trapezoidal acceleration)
 - **Display:** U8g2 (128x64 SSD1306 OLED)
-- **BLE:** NimBLE-Arduino 2.1.2
+- **BLE:** NimBLE-Arduino 2.4.0 on V2; omitted from V1
 - **LED:** FastLED (WS2812B status indicator)
-- **Build:** PlatformIO with 5 environments (development, developmentAJ, staging, production, test)
+- **Build:** PlatformIO with explicit 4 MiB V1 and 16 MiB V2 release environments
 
 ## Quick Commands
 
 ```bash
 pio run -e development            # Build development
+pio run -e production-v1          # Build universal 4 MiB firmware without BLE
+pio run -e production-v2          # Build full 16 MiB firmware with BLE
 pio run -e development -t upload  # Build + upload
 pio run -e development -t monitor # Serial monitor (115200 baud)
 pio run -e test -t test           # Run unit tests (native platform)
@@ -30,7 +32,7 @@ pio check                         # Run clang-tidy static analysis
 
 ```
 Software/
-├── platformio.ini               # Build config (5 environments)
+├── platformio.ini               # Build config and hardware variants
 ├── pre_build_script.py          # Build-time version injection
 ├── src/
 │   ├── main.cpp                 # Entry point, FreeRTOS task creation
@@ -190,22 +192,24 @@ struct SettingPercents {
 
 ### Environments
 
-| Env           | Debug | Platform         | Notable Flags                        |
-|---------------|-------|------------------|--------------------------------------|
-| development   | 4     | espressif32@6.3.2| `DEBUG_TALKATIVE`, `PRETEND_TO_BE_FLESHY_THRUST_SYNC` |
-| developmentAJ | 4     | espressif32      | Custom hardware, hardcoded WiFi      |
-| staging       | 1     | espressif32      | `PRETEND_TO_BE_FLESHY_THRUST_SYNC`   |
-| production    | 0     | espressif32      | `PRETEND_TO_BE_FLESHY_THRUST_SYNC`   |
-| test          | 0     | native           | `UNITY_INCLUDE_DOUBLE`, ArduinoFake  |
+| Env | Flash | BLE | Purpose |
+|-----|-------|-----|---------|
+| development | 16 MiB | Yes | Local development |
+| staging-v1 / production-v1 | 4 MiB | No | Universal compact release lane |
+| staging-v2 / production-v2 | 16 MiB | Yes | Full release lane |
+| staging / production | 16 MiB | Yes | Compatibility aliases pinned to V2 |
+| test | Native | No | Unity unit tests |
 
 ### Build Script
 
 `pre_build_script.py` runs before compilation:
 - Sets `SW_VERSION` from environment or GITHUB_ENV
+- Selects 4 MiB, Bluetooth-disabled ESP-IDF defaults for V1 builds
 
 ### Flash Partitions
 
-Uses `min_spiffs.csv` (PlatformIO built-in minimal SPIFFS partition).
+- `partition-v1.csv` preserves the historical 4 MiB OTA/SPIFFS layout.
+- `partition-v2.csv` uses the full 16 MiB flash with two 7.5 MiB OTA slots.
 
 ## Libraries
 

--- a/Software/lib/OssmHardwareVariant/src/OssmHardwareVariant.h
+++ b/Software/lib/OssmHardwareVariant/src/OssmHardwareVariant.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifndef OSSM_ENABLE_RAD_BLE
+#define OSSM_ENABLE_RAD_BLE 1
+#endif
+
+#ifndef OSSM_HARDWARE_VARIANT
+#define OSSM_HARDWARE_VARIANT "v2"
+#endif
+
+namespace ossm_hardware {
+
+inline constexpr const char *HARDWARE_VARIANT = OSSM_HARDWARE_VARIANT;
+inline constexpr bool RAD_BLE_ENABLED = OSSM_ENABLE_RAD_BLE == 1;
+
+static_assert(OSSM_ENABLE_RAD_BLE == 0 || OSSM_ENABLE_RAD_BLE == 1,
+              "OSSM_ENABLE_RAD_BLE must be 0 or 1");
+
+}  // namespace ossm_hardware

--- a/Software/partition-v1.csv
+++ b/Software/partition-v1.csv
@@ -1,0 +1,7 @@
+# Name,Type,SubType,Offset,Size,Flags
+nvs,data,nvs,0x9000,0x5000,
+otadata,data,ota,0xe000,0x2000,
+app0,app,ota_0,0x10000,0x1E0000,
+app1,app,ota_1,0x1F0000,0x1E0000,
+spiffs,data,spiffs,0x3D0000,0x20000,
+coredump,data,coredump,0x3F0000,0x10000,

--- a/Software/partition-v2.csv
+++ b/Software/partition-v2.csv
@@ -1,0 +1,6 @@
+# Name,Type,SubType,Offset,Size,Flags
+nvs,data,nvs,0x9000,0x5000,
+otadata,data,ota,0xe000,0x2000,
+app0,app,ota_0,0x10000,0x780000,
+app1,app,ota_1,0x790000,0x780000,
+spiffs,data,spiffs,0xF10000,0xF0000,

--- a/Software/platformio.ini
+++ b/Software/platformio.ini
@@ -12,9 +12,6 @@
 default_envs = development
 
 [common]
-board_build.partitions = min_spiffs.csv
-board_upload.flash_size = 16MB
-board_upload.maximum_size = 16777216
 build_unflags =
     -std=gnu++11
 build_flags =
@@ -23,8 +20,6 @@ build_flags =
     -Wno-unknown-pragmas
     -D FIRMWARE_USE_IDF_CRT_BUNDLE
 lib_deps =
-    https://github.com/researchanddesire/rad-ble.git#v1.0.0
-    h2zero/NimBLE-Arduino@2.4.0
     https://github.com/tzapu/WiFiManager.git
     gin66/FastAccelStepper@^0.30.13
     bblanchon/ArduinoJson@^7.4.2
@@ -40,7 +35,18 @@ check_flags =
     clangtidy: --checks=-\*,bugprone-*,boost-*,modernize-*,performance-*,clang-analyzer-*,cert-dcl03-c,cert-dcl21-cpp,cert-dcl58-cpp,cert-err34-c,cert-err52-cpp,cert-err58-cpp,cert-err60-cpp,cert-flp30-c,cert-msc50-cpp,cert-msc51-cpp,cert-oop54-cpp,cert-str34-c,cppcoreguidelines-interfaces-global-init,cppcoreguidelines-narrowing-conversions,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-pro-type-static-cast-downcast,cppcoreguidelines-slicing,google-default-arguments,google-explicit-constructor,google-runtime-operator,hicpp-exception-baseclass,hicpp-multiway-paths-covered,hicpp-signed-bitwise,portability-simd-intrinsics,readability-avoid-const-params-in-decls,readability-const-return-type,readability-container-size-empty,readability-convert-member-functions-to-static,readability-delete-null-pointer,readability-deleted-default,readability-inconsistent-declaration-parameter-name,readability-make-member-function-const,readability-misleading-indentation,readability-misplaced-array-index,readability-non-const-parameter,readability-redundant-control-flow,readability-redundant-declaration,readability-redundant-function-ptr-dereference,readability-redundant-smartptr-get,readability-simplify-subscript-expr,readability-static-accessed-through-instance,readability-static-definition-in-anonymous-namespace,readability-string-compare,readability-uniqueptr-delete-release,readability-use-anyofallof,-modernize-use-trailing-return-type,-readability-convert-member-functions-to-static,-bugprone-easily-swappable-parameters,-readability-make-member-function-const --fix
 extra_scripts = pre:pre_build_script.py, pre:firmware_build_metadata.py
 
+[common_ble]
+lib_deps =
+    https://github.com/researchanddesire/rad-ble.git#v1.0.0
+    h2zero/NimBLE-Arduino@2.4.0
+
 [env:development]
+board_build.partitions = partition-v2.csv
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+lib_deps =
+    ${common.lib_deps}
+    ${common_ble.lib_deps}
 build_flags =
     -D CORE_DEBUG_LEVEL=4
     -D FIRMWARE_USE_IDF_CRT_BUNDLE
@@ -58,6 +64,8 @@ build_flags =
     -D WIFI_SSID="\"CANADAHOUSE_2.4G\""
     -D WIFI_PASSWORD="\"timbytes\""
     -D PRETEND_TO_BE_FLESHY_THRUST_SYNC
+    -D OSSM_ENABLE_RAD_BLE=1
+    -D OSSM_HARDWARE_VARIANT="\"v2\""
     -D RAD_SERVER="\"http://localhost:3000\""
     -D MQTT_USERNAME="\"TEST\""
     -D MQTT_PASSWORD="\"Hello123!\""
@@ -69,7 +77,7 @@ monitor_speed = 115200
 monitor_filters = colorize, esp32_exception_decoder, time
 targets = upload, monitor
 
-[env:staging]
+[staging_common]
 build_flags =
     -D CORE_DEBUG_LEVEL=3
     -D FIRMWARE_USE_IDF_CRT_BUNDLE
@@ -82,19 +90,16 @@ build_flags =
     -D MQTT_SERVER="\"mqtts://te9acc16.ala.us-east-1.emqxsl.com\""
     -D MQTT_PORT=8883
     -D RAD_SERVER_SHORT="\"https://staging.researchanddesire.com\""
-    -D CONFIG_NIMBLE_CPP_LOG_LEVEL=0
-    -D CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE=6144
     -D PRETEND_TO_BE_FLESHY_THRUST_SYNC
     -D RAD_SERVER="\"https://staging.researchanddesire.com\""
     -D MQTT_USERNAME="\"5k0vjgg9hCwZGAFnmFJg7nTU6sDElr43\""
     -D MQTT_PASSWORD="\"tJDV2u8eGdMBPzHlGKQBnirCrrA9zg5w\""
-extends = common
 platform = espressif32
 board = esp32dev
 framework = arduino, espidf
 monitor_speed = 115200
 
-[env:production]
+[production_common]
 build_flags =
     -D CORE_DEBUG_LEVEL=2
     -D FIRMWARE_USE_IDF_CRT_BUNDLE
@@ -107,17 +112,66 @@ build_flags =
     -D MQTT_SERVER="\"mqtts://te9acc16.ala.us-east-1.emqxsl.com\""
     -D MQTT_PORT=8883
     -D RAD_SERVER_SHORT="\"https://dashboard.researchanddesire.com\""
-    -D CONFIG_NIMBLE_CPP_LOG_LEVEL=0
-    -D CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE=6144
     -D PRETEND_TO_BE_FLESHY_THRUST_SYNC
     -D RAD_SERVER="\"https://dashboard.researchanddesire.com\""
     -D MQTT_USERNAME="\"5k0vjgg9hCwZGAFnmFJg7nTU6sDElr43\""
     -D MQTT_PASSWORD="\"tJDV2u8eGdMBPzHlGKQBnirCrrA9zg5w\""
-extends = common
 platform = espressif32
 board = esp32dev
 framework = arduino, espidf
 monitor_speed = 115200
+
+[variant_v1]
+board_build.partitions = partition-v1.csv
+board_upload.flash_size = 4MB
+board_upload.maximum_size = 4194304
+build_flags =
+    -D OSSM_ENABLE_RAD_BLE=0
+    -D OSSM_HARDWARE_VARIANT="\"v1\""
+
+[variant_v2]
+board_build.partitions = partition-v2.csv
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+lib_deps =
+    ${common.lib_deps}
+    ${common_ble.lib_deps}
+build_flags =
+    -D OSSM_ENABLE_RAD_BLE=1
+    -D OSSM_HARDWARE_VARIANT="\"v2\""
+    -D CONFIG_NIMBLE_CPP_LOG_LEVEL=0
+    -D CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE=6144
+
+[env:staging-v1]
+extends = common, staging_common, variant_v1
+build_flags =
+    ${staging_common.build_flags}
+    ${variant_v1.build_flags}
+
+[env:staging-v2]
+extends = common, staging_common, variant_v2
+build_flags =
+    ${staging_common.build_flags}
+    ${variant_v2.build_flags}
+
+[env:production-v1]
+extends = common, production_common, variant_v1
+build_flags =
+    ${production_common.build_flags}
+    ${variant_v1.build_flags}
+
+[env:production-v2]
+extends = common, production_common, variant_v2
+build_flags =
+    ${production_common.build_flags}
+    ${variant_v2.build_flags}
+
+; Existing environment names remain aliases for the 16 MiB Bluetooth build.
+[env:staging]
+extends = env:staging-v2
+
+[env:production]
+extends = env:production-v2
 
 [env:hw_test]
 extends = env:development

--- a/Software/pre_build_script.py
+++ b/Software/pre_build_script.py
@@ -3,6 +3,21 @@ import os
 import re
 import socket
 
+
+def configure_release_sdkconfig():
+    """Layer compact-board IDF defaults over the shared release config."""
+    pio_env = env.subst("$PIOENV")
+    project_dir = env.subst("$PROJECT_DIR")
+    defaults = [os.path.join(project_dir, "sdkconfig.defaults")]
+    if pio_env.endswith("-v1"):
+        defaults.append(os.path.join(project_dir, "sdkconfig-v1.defaults"))
+        print("Using 4 MB, Bluetooth-disabled ESP-IDF defaults")
+    env["ENV"]["SDKCONFIG_DEFAULTS"] = ";".join(defaults)
+
+
+configure_release_sdkconfig()
+
+
 def get_local_ip():
     try:
         # Create a socket connection to an external server (doesn't actually connect)

--- a/Software/sdkconfig-v1.defaults
+++ b/Software/sdkconfig-v1.defaults
@@ -1,0 +1,4 @@
+# Compact OSSM hardware has 4 MiB flash and does not expose Bluetooth.
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="4MB"
+# CONFIG_BT_ENABLED is not set

--- a/Software/src/components/HeaderBar.cpp
+++ b/Software/src/components/HeaderBar.cpp
@@ -70,19 +70,19 @@ void drawWifiIcon() {
 }
 
 BleStatus getBleStatus() {
-    if (pServer == nullptr) {
+    if (!ossm_hardware::RAD_BLE_ENABLED) {
         return BleStatus::DISCONNECTED;
     }
 
-    if (pServer->getAdvertising() && pServer->getConnectedCount() == 0) {
+    if (nimbleIsAdvertising() && nimbleConnectionCount() == 0) {
         return BleStatus::ADVERTISING;
     }
 
-    if (pServer->getConnectedCount() > 0) {
+    if (nimbleConnectionCount() > 0) {
         return BleStatus::CONNECTED;
     }
 
-    if (pServer->getAdvertising()) {
+    if (nimbleIsAdvertising()) {
         return BleStatus::CONNECTING;
     }
 
@@ -145,7 +145,7 @@ void drawBleIcon() {
         if (xSemaphoreTake(displayMutex, 100) == pdTRUE) {
             clearIcons();
             drawWifiIcon();
-            drawBleIcon();
+            if (ossm_hardware::RAD_BLE_ENABLED) drawBleIcon();
             refreshIcons();
             xSemaphoreGive(displayMutex);
         }
@@ -171,7 +171,8 @@ void drawBleIcon() {
         }
 
         bool wifiChanged = shouldDrawWifiIcon() || stateChanged;
-        bool bleChanged = shouldDrawBleIcon() || stateChanged;
+        bool bleChanged = ossm_hardware::RAD_BLE_ENABLED &&
+                          (shouldDrawBleIcon() || stateChanged);
 
         updateLEDForMachineStatus();
 
@@ -183,7 +184,7 @@ void drawBleIcon() {
         if (xSemaphoreTake(displayMutex, 100) == pdTRUE) {
             clearIcons();
             drawWifiIcon();
-            drawBleIcon();
+            if (ossm_hardware::RAD_BLE_ENABLED) drawBleIcon();
             refreshIcons();
             xSemaphoreGive(displayMutex);
         } else {

--- a/Software/src/services/board.h
+++ b/Software/src/services/board.h
@@ -2,7 +2,6 @@
 #define OSSM_SOFTWARE_BOARD_H
 
 #include <Arduino.h>
-#include <NimBLEDevice.h>
 
 #include "constants/Pins.h"
 #include "services/encoder.h"

--- a/Software/src/services/communication/nimble.cpp
+++ b/Software/src/services/communication/nimble.cpp
@@ -1,5 +1,7 @@
 #include "nimble.h"
 
+#if OSSM_ENABLE_RAD_BLE
+
 #include <ArduinoJson.h>
 #include <constants/LogTags.h>
 #include <services/board.h>
@@ -385,3 +387,20 @@ void initNimble() {
         nimbleLoop, "nimbleLoop", 5 * configMINIMAL_STACK_SIZE, pServer,
         configMAX_PRIORITIES - 1, nullptr, Tasks::stepperCore);
 }
+
+int nimbleConnectionCount() {
+    return pServer == nullptr ? 0 : pServer->getConnectedCount();
+}
+
+bool nimbleIsAdvertising() {
+    return pServer != nullptr && pServer->getAdvertising();
+}
+
+#else
+
+void nimbleLoop(void*) {}
+void initNimble() {}
+int nimbleConnectionCount() { return 0; }
+bool nimbleIsAdvertising() { return false; }
+
+#endif

--- a/Software/src/services/communication/nimble.h
+++ b/Software/src/services/communication/nimble.h
@@ -1,9 +1,12 @@
 #ifndef OSSM_NIMBLE_H
 #define OSSM_NIMBLE_H
 
+#include <OssmHardwareVariant.h>
+
+#if OSSM_ENABLE_RAD_BLE
 #include <NimBLEDevice.h>
 #include <NimBLEServer.h>
-#include <esp_log.h>
+#endif
 
 #define SERVICE_UUID "522b443a-4f53-534d-0001-420badbabe69"
 
@@ -62,9 +65,13 @@
 #define SYSTEM_ID_UUID "2A23"            // Standard UUID for system ID
 #define DEVICE_INFO_SERVICE_UUID "180A"  // Device Information Service
 
+#if OSSM_ENABLE_RAD_BLE
 extern NimBLEServer* pServer;
+#endif
 
 void nimbleLoop(void* pvParameters);
 void initNimble();
+int nimbleConnectionCount();
+bool nimbleIsAdvertising();
 
 #endif  // OSSM_NIMBLE_H

--- a/Software/src/services/communication/rad_ble.cpp
+++ b/Software/src/services/communication/rad_ble.cpp
@@ -1,3 +1,7 @@
+#include <OssmHardwareVariant.h>
+
+#if OSSM_ENABLE_RAD_BLE
+
 #include "rad_ble.h"
 
 #include <Preferences.h>
@@ -689,7 +693,9 @@ bool initRadBle(NimBLEServer* server) {
             .serviceUuid = radble::OSSM_SERVICE_UUID,
             .firmwareVersion = VERSION,
             .build = FIRMWARE_BUILD_SHA,
-            .partitionLayout = "ossm-ota-16mb-v1",
+            .partitionLayout = ossm_hardware::HARDWARE_VARIANT[1] == '1'
+                                   ? "ossm-ota-4mb-v1"
+                                   : "ossm-ota-16mb-v1",
         },
         .capabilities = radble::CAP_BUTTON | radble::CAP_ENCODER |
                         radble::CAP_ANALOG | radble::CAP_MOTION |
@@ -711,3 +717,5 @@ bool initRadBle(NimBLEServer* server) {
     };
     return radBleServer.begin(server, config);
 }
+
+#endif

--- a/Software/src/utils/update.cpp
+++ b/Software/src/utils/update.cpp
@@ -10,6 +10,7 @@
 #include <esp_system.h>
 
 #include "FirmwareUpdateRuntime.h"
+#include <OssmHardwareVariant.h>
 #include "constants/LogTags.h"
 #include "constants/Version.h"
 #include "ossm/Events.h"
@@ -51,9 +52,9 @@ const char *currentPartitionLayout() {
         app1->address == 0x790000 && app1->size == 0x780000) {
         return "ossm-ota-16mb-v1";
     }
-    if (app0->address == 0x10000 && app0->size == 0x1F0000 &&
-        app1->address == 0x200000 && app1->size == 0x1F0000) {
-        return "ossm-ota-v1";
+    if (app0->address == 0x10000 && app0->size == 0x1E0000 &&
+        app1->address == 0x1F0000 && app1->size == 0x1E0000) {
+        return "ossm-ota-4mb-v1";
     }
     return "unknown";
 }
@@ -78,7 +79,8 @@ firmware::DeviceReport makeDeviceReport() {
     report.chip = std::string(ESP.getChipModel());
     report.chipRevision = ESP.getChipRevision();
     report.chipCores = ESP.getChipCores();
-    report.hardwareRevision = "ossm-v1";
+    report.hardwareRevision =
+        std::string("ossm-") + ossm_hardware::HARDWARE_VARIANT;
     report.flashSizeBytes = physicalFlashSizeBytes();
     report.psramSizeBytes = ESP.getPsramSize();
     report.otaSlotSizeBytes = otaSlotSizeBytes();


### PR DESCRIPTION
## Summary

- add explicit OSSM V1 and V2 hardware lanes: universal 4 MiB firmware without Bluetooth, and full 16 MiB firmware with Bluetooth
- build, validate, and publish separate immutable firmware and merged web-installer artifacts for both lanes
- route firmware checks and web-flasher catalogs by detected flash capacity
- expose both OSSM lanes in the admin release and device-management UI
- preserve existing OSSM releases and targets in V2 while enabling the new V1 lane

## Compatibility

- V1 preserves the historical 4 MiB partition layout and is the safe web-flasher default on either board size
- V2 uses the full 16 MiB layout; boards still using the historical layout can keep running V1 until they receive a full V2 web flash
- existing alpha, production, and legacy build aliases remain pinned to the 16 MiB V2 lane

## Verification

- clean production V1 and V2 firmware builds, including flash-header, partition-table, slot-size, and Bluetooth configuration checks
- validated 4 MiB and 16 MiB merged web installers
- 208 PlatformIO unit tests
- release-helper tests and workflow YAML parsing
- targeted web/admin tests, lint, and type checks for web, admin, docs-kit, and the user guide
- fresh local Supabase migration plus 229 database assertions

<!-- rad-bundle:start -->
Cross-repository bundle: `AJ/ossm-4mb-support`

- [rad-app #1862](https://github.com/researchanddesire/rad-app/pull/1862)
- [ossm #330](https://github.com/KinkyMakers/OSSM-hardware/pull/330)
<!-- rad-bundle:end -->
