### PR TITLE
hotfix Publish V1 and V2 with synchronized versions

### DIFF
--- a/.github/scripts/build_web_installer.py
+++ b/.github/scripts/build_web_installer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build and validate the merged 16 MiB OSSM browser-flashing image."""
+"""Build and validate the merged OSSM browser-flashing image."""
 
 from __future__ import annotations
 
@@ -20,6 +20,7 @@ ESP32_CHIP_ID = 0
 FLASH_MODE_ID = 2
 FLASH_SIZE_ID = 4
 FLASH_FREQUENCY_ID = 0
+FLASH_PROFILES = {4: (4 * 1024 * 1024, 2), 16: (FLASH_CAPACITY, FLASH_SIZE_ID)}
 
 
 def require_image(path: Path, label: str) -> Path:
@@ -70,8 +71,9 @@ def validate_esp_image(path: Path, label: str) -> None:
 
 
 def build_components(
-    build_dir: Path, boot_app0: Path
+    build_dir: Path, boot_app0: Path, flash_size_mib: int = 16
 ) -> list[tuple[int, Path]]:
+    flash_capacity, expected_size_id = FLASH_PROFILES[flash_size_mib]
     bootloader = require_image(build_dir / "bootloader.bin", "bootloader")
     application = require_image(build_dir / "firmware.bin", "application")
     validate_esp_image(bootloader, "bootloader")
@@ -83,15 +85,17 @@ def build_components(
     flash_frequency_id = bootloader_header[3] & 0xF
     if (
         flash_mode_id != FLASH_MODE_ID
-        or flash_size_id != FLASH_SIZE_ID
+        or flash_size_id != expected_size_id
         or flash_frequency_id != FLASH_FREQUENCY_ID
     ):
         raise RuntimeError(
-            "bootloader flash header does not match OSSM's 16 MiB profile: "
+            f"bootloader flash header does not match OSSM's {flash_size_mib} MiB profile: "
             f"found mode/size/frequency IDs {flash_mode_id}/{flash_size_id}/"
-            f"{flash_frequency_id}, expected {FLASH_MODE_ID}/{FLASH_SIZE_ID}/"
+            f"{flash_frequency_id}, expected {FLASH_MODE_ID}/{expected_size_id}/"
             f"{FLASH_FREQUENCY_ID}"
         )
+    if application.read_bytes()[2:4] != bootloader_header[2:4]:
+        raise RuntimeError("application flash header does not match the bootloader profile")
 
     components = [
         (
@@ -113,7 +117,7 @@ def build_components(
     ]
     for index, (offset, path) in enumerate(components):
         end = offset + path.stat().st_size
-        if end > FLASH_CAPACITY:
+        if end > flash_capacity:
             raise RuntimeError(f"{path} exceeds the physical flash capacity")
         if index + 1 < len(components) and end > components[index + 1][0]:
             raise RuntimeError(f"{path} overlaps the next flash component")
@@ -121,7 +125,7 @@ def build_components(
 
 
 def merge_command(
-    esptool: Path, output: Path, components: list[tuple[int, Path]]
+    esptool: Path, output: Path, components: list[tuple[int, Path]], flash_size_mib: int = 16
 ) -> list[str]:
     command = [
         sys.executable,
@@ -136,7 +140,7 @@ def merge_command(
         "--flash_freq",
         "keep",
         "--flash_size",
-        "16MB",
+        f"{flash_size_mib}MB",
     ]
     for offset, path in components:
         command.extend((hex(offset), str(path)))
@@ -144,12 +148,13 @@ def merge_command(
 
 
 def validate_merged_image(
-    output: Path, components: list[tuple[int, Path]]
+    output: Path, components: list[tuple[int, Path]], flash_size_mib: int = 16
 ) -> None:
+    flash_capacity, flash_size_id = FLASH_PROFILES[flash_size_mib]
     content = require_image(output, "merged web installer").read_bytes()
-    if len(content) > FLASH_CAPACITY:
+    if len(content) > flash_capacity:
         raise RuntimeError(
-            f"merged image is {len(content)} bytes, beyond 16 MiB flash"
+            f"merged image is {len(content)} bytes, beyond {flash_size_mib} MiB flash"
         )
     for offset in (COMPONENT_OFFSETS["bootloader.bin"], 0x10000):
         if offset >= len(content) or content[offset] != 0xE9:
@@ -166,10 +171,12 @@ def validate_merged_image(
     ]
     if (
         header[2] != FLASH_MODE_ID
-        or header[3] >> 4 != FLASH_SIZE_ID
+        or header[3] >> 4 != flash_size_id
         or header[3] & 0xF != FLASH_FREQUENCY_ID
     ):
         raise RuntimeError("merged bootloader flash header does not match OSSM's profile")
+    if content[0x10002:0x10004] != header[2:4]:
+        raise RuntimeError("merged application flash header does not match OSSM's profile")
 
     for offset, source_path in components:
         source = source_path.read_bytes()
@@ -183,11 +190,13 @@ def validate_merged_image(
             raise RuntimeError(f"merged component mismatch at {hex(offset)}")
 
 
-def build(build_dir: Path, output: Path, boot_app0: Path | None = None) -> None:
-    components = build_components(build_dir, boot_app0 or find_boot_app0())
+def build(
+    build_dir: Path, output: Path, boot_app0: Path | None = None, flash_size_mib: int = 16
+) -> None:
+    components = build_components(build_dir, boot_app0 or find_boot_app0(), flash_size_mib)
     output.parent.mkdir(parents=True, exist_ok=True)
-    subprocess.run(merge_command(find_esptool(), output, components), check=True)
-    validate_merged_image(output, components)
+    subprocess.run(merge_command(find_esptool(), output, components, flash_size_mib), check=True)
+    validate_merged_image(output, components, flash_size_mib)
 
 
 def main() -> int:
@@ -195,9 +204,10 @@ def main() -> int:
     parser.add_argument("--build-dir", required=True, type=Path)
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--boot-app0", type=Path)
+    parser.add_argument("--flash-size", choices=("4MB", "16MB"), default="16MB")
     args = parser.parse_args()
     try:
-        build(args.build_dir, args.output, args.boot_app0)
+        build(args.build_dir, args.output, args.boot_app0, int(args.flash_size[:-2]))
         print(f"Built validated web installer: {args.output}")
         return 0
     except Exception as error:

--- a/.github/scripts/test_build_web_installer.py
+++ b/.github/scripts/test_build_web_installer.py
@@ -26,6 +26,62 @@ class BuildWebInstallerTests(unittest.TestCase):
         self.assertIn("16MB", command)
         self.assertEqual(MODULE.FLASH_CAPACITY, 16 * 1024 * 1024)
 
+    def test_4_mib_headers_capacity_and_component_preservation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            header = b"\xe9\x01\x02\x20" + b"\0" * 12
+            for name, content in (
+                ("bootloader.bin", header),
+                ("partitions.bin", b"partition-table"),
+                ("boot_app0.bin", b"boot-app"),
+                ("firmware.bin", header + b"application"),
+            ):
+                (root / name).write_bytes(content)
+            components = MODULE.build_components(root, root / "boot_app0.bin", 4)
+            with self.assertRaisesRegex(RuntimeError, "16 MiB profile"):
+                MODULE.build_components(root, root / "boot_app0.bin")
+            output = root / "web-installer.bin"
+            command = MODULE.merge_command(root / "esptool.py", output, components, 4)
+            self.assertEqual(command[command.index("--flash_size") + 1], "4MB")
+            for option in ("--flash_mode", "--flash_freq"):
+                self.assertEqual(command[command.index(option) + 1], "keep")
+
+            merged = bytearray(b"\xff" * 0x10020)
+            for offset, path in components:
+                content = path.read_bytes()
+                merged[offset : offset + len(content)] = content
+            output.write_bytes(merged)
+            MODULE.validate_merged_image(output, components, 4)
+            with self.assertRaisesRegex(RuntimeError, "flash header"):
+                MODULE.validate_merged_image(output, components)
+            for offset, path in components:
+                with self.subTest(component=path.name):
+                    index = offset + path.stat().st_size - 1
+                    merged[index] ^= 1
+                    output.write_bytes(merged)
+                    with self.assertRaisesRegex(RuntimeError, "component mismatch"):
+                        MODULE.validate_merged_image(output, components, 4)
+                    merged[index] ^= 1
+
+            output.write_bytes(merged + b"\xff" * (4 * 1024 * 1024 + 1 - len(merged)))
+            with self.assertRaisesRegex(RuntimeError, "beyond 4 MiB flash"):
+                MODULE.validate_merged_image(output, components, 4)
+            application = root / "firmware.bin"
+            with application.open("r+b") as image:
+                image.truncate(4 * 1024 * 1024 - 0x10000)
+            MODULE.build_components(root, root / "boot_app0.bin", 4)
+            with application.open("ab") as image:
+                image.write(b"\0")
+            with self.assertRaisesRegex(RuntimeError, "physical flash capacity"):
+                MODULE.build_components(root, root / "boot_app0.bin", 4)
+            (root / "bootloader.bin").write_bytes(header[:3] + b"\x40" + header[4:])
+            with self.assertRaisesRegex(RuntimeError, "4 MiB profile"):
+                MODULE.build_components(root, root / "boot_app0.bin", 4)
+            with application.open("r+b") as image:
+                image.seek(3)
+                image.write(b"\x40")
+            MODULE.build_components(root, root / "boot_app0.bin")
+
     def test_rejects_the_wrong_chip_or_flash_header(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -34,7 +90,7 @@ class BuildWebInstallerTests(unittest.TestCase):
             partitions = root / "partitions.bin"
             boot_app0 = root / "boot_app0.bin"
             bootloader.write_bytes(b"\xe9\x01\x02\x40" + b"\0" * 10)
-            application.write_bytes(b"\xe9\x01\x00\x00" + b"\0" * 10)
+            application.write_bytes(b"\xe9\x01\x02\x40" + b"\0" * 10)
             partitions.write_bytes(b"partitions")
             boot_app0.write_bytes(b"boot-app")
             MODULE.build_components(root, boot_app0)
@@ -43,10 +99,16 @@ class BuildWebInstallerTests(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "flash header"):
                 MODULE.build_components(root, boot_app0)
 
+            bootloader.write_bytes(b"\xe9\x01\x02\x40" + b"\0" * 10)
+            for profile in (b"\x00\x40", b"\x02\x20", b"\x02\x41"):
+                with self.subTest(application_profile=profile):
+                    application.write_bytes(b"\xe9\x01" + profile + b"\0" * 10)
+                    with self.assertRaisesRegex(RuntimeError, "application flash header"):
+                        MODULE.build_components(root, boot_app0)
+
             application.write_bytes(
                 b"\xe9\x01\x00\x00" + b"\0" * 8 + b"\x09\x00"
             )
-            bootloader.write_bytes(b"\xe9\x01\x02\x40" + b"\0" * 10)
             with self.assertRaisesRegex(RuntimeError, "chip ID"):
                 MODULE.build_components(root, boot_app0)
 
@@ -65,6 +127,7 @@ class BuildWebInstallerTests(unittest.TestCase):
             application = bytearray(16)
             application[0] = 0xE9
             application[1] = 1
+            application[2:4] = bootloader[2:4]
             application[12:14] = MODULE.ESP32_CHIP_ID.to_bytes(2, "little")
             for offset, name, body in (
                 (0x1000, "bootloader.bin", bytes(bootloader)),
@@ -83,6 +146,12 @@ class BuildWebInstallerTests(unittest.TestCase):
             output = root / "web-installer.bin"
             output.write_bytes(merged)
             MODULE.validate_merged_image(output, components)
+
+            merged[0x10003] = 0x20
+            output.write_bytes(merged)
+            with self.assertRaisesRegex(RuntimeError, "application flash header"):
+                MODULE.validate_merged_image(output, components)
+            merged[0x10003] = 0x40
 
             merged[0x10000] = 0
             output.write_bytes(merged)

--- a/.github/workflows/publish_firmware.yml
+++ b/.github/workflows/publish_firmware.yml
@@ -161,6 +161,31 @@ jobs:
         working-directory: Software
         run: pio run -e "$PIO_ENV"
 
+      - name: Checkout V1 firmware with Bluetooth
+        if: github.ref_name == 'main'
+        uses: actions/checkout@v4
+        with:
+          ref: 065c1c70d8be0b6ebe3edf536051ca542b793d70 # Legacy source; release version is synchronized below.
+          path: legacy-4mb
+
+      - name: Test and build V1 with the allocated version
+        if: github.ref_name == 'main'
+        run: |
+          python scripts/release_version.py write --version "${{ steps.version.outputs.version }}" \
+            --header legacy-4mb/Software/src/constants/Version.h --version-json legacy-4mb/version.json
+          pio test --project-dir legacy-4mb/Software -e test
+          pio run --project-dir legacy-4mb/Software -e production -t buildprog
+          grep -aFq "$RELEASE_BUILD_SHA" legacy-4mb/Software/.pio/build/production/firmware.bin
+          grep -aFq "${{ steps.version.outputs.version }}" legacy-4mb/Software/.pio/build/production/firmware.bin
+          test "$(stat --format=%s legacy-4mb/Software/.pio/build/production/firmware.bin)" -le $((0x1E0000 - 0x4000))
+          grep -qx 'CONFIG_BT_ENABLED=y' legacy-4mb/Software/sdkconfig.production
+          grep -qx 'CONFIG_ESPTOOLPY_FLASHSIZE="4MB"' legacy-4mb/Software/sdkconfig.production
+          ~/.platformio/packages/toolchain-xtensa-esp32/bin/xtensa-esp32-elf-nm \
+            legacy-4mb/Software/.pio/build/production/firmware.elf | grep -E 'NimBLEServer' > /dev/null
+          python .github/scripts/build_web_installer.py --flash-size 4MB \
+            --build-dir legacy-4mb/Software/.pio/build/production \
+            --output legacy-4mb/Software/.pio/build/production/web-installer.bin
+
       - name: Build merged web installer
         run: |
           python .github/scripts/build_web_installer.py \
@@ -182,8 +207,25 @@ jobs:
             --artifact "partitions:Software/.pio/build/$PIO_ENV/partitions.bin:3:false" \
             --artifact "web-installer:Software/.pio/build/$PIO_ENV/web-installer.bin:4:false"
 
+      - name: Publish validating V1 release
+        if: github.ref_name == 'main'
+        id: publish_v1
+        run: |
+          python .github/scripts/publish_immutable_firmware.py \
+            --device-type ossm --hardware-variant v1 --track "$TRACK" \
+            --build-sha "$RELEASE_BUILD_SHA" \
+            --version-file legacy-4mb/Software/src/constants/Version.h \
+            --min-flash-size-bytes 4194304 \
+            --artifact "application:legacy-4mb/Software/.pio/build/production/firmware.bin:1:true" \
+            --artifact "bootloader:legacy-4mb/Software/.pio/build/production/bootloader.bin:2:false" \
+            --artifact "partitions:legacy-4mb/Software/.pio/build/production/partitions.bin:3:false" \
+            --artifact "web-installer:legacy-4mb/Software/.pio/build/production/web-installer.bin:4:false"
+
       - name: Candidate summary
         run: |
-          echo "Release ${{ steps.publish.outputs.release_id }} is waiting for hardware validation" >> "$GITHUB_STEP_SUMMARY"
+          echo "V2 release ${{ steps.publish.outputs.release_id }} is waiting for hardware validation" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -n "${{ steps.publish_v1.outputs.release_id }}" ]]; then
+            echo "V1 release ${{ steps.publish_v1.outputs.release_id }} is waiting for hardware validation" >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo "Version: ${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "Build: ${{ steps.version.outputs.release_build_sha }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pull_request_action.yml
+++ b/.github/workflows/pull_request_action.yml
@@ -90,24 +90,31 @@ jobs:
 
       - name: Test and build legacy 4 MB firmware
         run: |
+          VERSION="$(python scripts/release_version.py read --header Software/src/constants/Version.h)"
+          python scripts/release_version.py write --version "$VERSION" \
+            --header legacy-4mb/Software/src/constants/Version.h --version-json legacy-4mb/version.json
           pio test --project-dir legacy-4mb/Software -e test
-          RELEASE_BUILD_SHA=$(git -C legacy-4mb rev-parse HEAD) pio run --project-dir legacy-4mb/Software -e production -t buildprog
-          grep -aFq "$(git -C legacy-4mb rev-parse HEAD)" legacy-4mb/Software/.pio/build/production/firmware.bin
-          test "$(python scripts/release_version.py read --header legacy-4mb/Software/src/constants/Version.h)" = 1.0.39
+          RELEASE_BUILD_SHA=$(git rev-parse HEAD) pio run --project-dir legacy-4mb/Software -e production -t buildprog
+          grep -aFq "$(git rev-parse HEAD)" legacy-4mb/Software/.pio/build/production/firmware.bin
+          grep -aFq "$VERSION" legacy-4mb/Software/.pio/build/production/firmware.bin
           test "$(stat --format=%s legacy-4mb/Software/.pio/build/production/firmware.bin)" -le $((0x1E0000 - 0x4000))
           grep -qx 'CONFIG_BT_ENABLED=y' legacy-4mb/Software/sdkconfig.production
           grep -qx 'CONFIG_ESPTOOLPY_FLASHSIZE="4MB"' legacy-4mb/Software/sdkconfig.production
           ~/.platformio/packages/toolchain-xtensa-esp32/bin/xtensa-esp32-elf-nm \
             legacy-4mb/Software/.pio/build/production/firmware.elf | grep -E 'NimBLEServer' > /dev/null
+          python .github/scripts/build_web_installer.py --flash-size 4MB \
+            --build-dir legacy-4mb/Software/.pio/build/production \
+            --output legacy-4mb/Software/.pio/build/production/web-installer.bin
 
       - name: Upload legacy 4 MB firmware artifact
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-4mb-1.0.39
+          name: firmware-v1
           path: |
             legacy-4mb/Software/.pio/build/production/firmware.bin
             legacy-4mb/Software/.pio/build/production/partitions.bin
             legacy-4mb/Software/.pio/build/production/bootloader.bin
+            legacy-4mb/Software/.pio/build/production/web-installer.bin
           if-no-files-found: error
           retention-days: 1
 


### PR DESCRIPTION
The production workflow uploaded only V2 even though the 4 MB build passed. This hotfix publishes V1 and V2 with one allocated version and build identity, keeping Bluetooth on both.

V1 is rebuilt from the Bluetooth-enabled source pinned at `065c1c70d8be0b6ebe3edf536051ca542b793d70`, with the allocated version written into its header and metadata before compilation. Both images embed the main commit that defines their build recipes. This preserves the older V1 implementation and synchronizes release numbering without relabeling an old binary. V1 publication remains main-only because that source targets production. The separate current-source 4 MB optimization is unchanged.

Both builds, native tests, Bluetooth/flash-size assertions and installers finish before either production upload. The installer helper accepts `--flash-size 4MB|16MB`, preserves the 16 MB default, and rejects mismatched application/bootloader headers. No firmware feature is disabled. The patch changes four files: 152 additions and 24 deletions, including 73 changed test lines.

Merged by AJ as `9a53597e42403f7fc240738d1c179ce45f016d03`. [Production publication succeeded](https://github.com/KinkyMakers/OSSM-hardware/actions/runs/33434966845): both variants are **1.0.58**, build `081c84b32fa447324d20814e21dd7c0b986f13f9`.

| Published variant | Minimum flash | Validating release ID |
| --- | --- | --- |
| V1 | 4 MB | `94cf3aff-8a55-4ace-92f6-e8b2c13a644f` |
| V2 | 16 MB | `f9ef02b6-42d2-4423-abf5-f65b1913aac1` |

Both publication builds passed 208/208 native tests. Both publishers verified uploaded object hashes and sizes before creating the release records. Neither release was promoted past its remaining validation gates.

[PR CI passed](https://github.com/KinkyMakers/OSSM-hardware/actions/runs/33433305800), including both builds and artifact uploads. Archive digests, ESP32 image checksums, flash headers, exact partition geometry/MD5, OTA reserve, embedded identities and merged installer components were independently verified. V1 is 1,906,336 bytes, leaving 43,360 bytes below its guarded app-size limit.

The exact uploaded **PR CI 1.0.57** images, common build `f7b528c1433a48a385c6d3f4da45374cfaffd98d`, were flashed to the matching physical boards, 16 MB first and then 4 MB. All four flash segments verified on each board. Serial capture continued through BLE cleanup: 684.53 seconds on 16 MB and 592.57 seconds on 4 MB, with no unexpected reset or fatal marker after the initial controlled-reset burst. Live BLE confirmed each board's exact version and application checksum. Each passed six RADR GATT characteristics, 40 full state reads, the speed-knob toggle, seven pattern descriptions, and change/read/restore checks for stroke, depth, sensation and pattern. V2 additionally passed 48 full-state reads and 30 compact notifications across two subscription cycles.

These were stopped-state bench checks with the user's camera waiver. Homing timed out into `error.idle`; no motion mode or positive speed was commanded. V2 cloud pairing still has nonfatal TLS allocation failures and is not claimed successful. V1's final speed-zero ACK remains a known legacy limitation: five ACK observations are retained as JSON failures, not counted as state-read passes or proof of physical stop. Menu transitions and exact empty description-cache restoration are not claimed. All BLE sessions and serial monitors were explicitly closed.

The tested PR images are **not** the later allocated 1.0.58 release binaries. Those candidates still need their exact-image hardware and remaining validation records. No gate was bypassed, and no direct production-object download was performed without the project ref required by AGENTS.md.

Previous boot/BLE fixes: [OSSM #334](https://github.com/KinkyMakers/OSSM-hardware/pull/334), [shared BLE #1](https://github.com/researchanddesire/rad-ble/pull/1). Automatic main-to-staging synchronization remains blocked by the missing `HOTFIX_SYNC_TOKEN`; AJ closed [manual sync #337](https://github.com/KinkyMakers/OSSM-hardware/pull/337), which has not been reopened.
