### PR TITLE
Race condition in Stroke Engine

### DIFF
--- a/Software/src/ossm/pattern_controls/pattern_controls.cpp
+++ b/Software/src/ossm/pattern_controls/pattern_controls.cpp
@@ -44,6 +44,7 @@ static void drawPatternControlsTask(void *pvParameters) {
     showHeaderIcons = true;
 
     while (isInCorrectState()) {
+        nextPattern = encoder.readEncoder() / 3;
         float speed;
         float speedKnob =
             getAnalogAveragePercent(SampleOnPin{Pins::Remote::speedPotPin, 50});
@@ -60,7 +61,6 @@ static void drawPatternControlsTask(void *pvParameters) {
             settings.speed = speed;
         }
 
-        nextPattern = encoder.readEncoder() / 3;
         shouldUpdateDisplay =
             shouldUpdateDisplay || (int)settings.pattern != nextPattern;
         if (!shouldUpdateDisplay) {

--- a/Software/src/ossm/play_controls/play_controls.cpp
+++ b/Software/src/ossm/play_controls/play_controls.cpp
@@ -80,6 +80,8 @@ static void drawPlayControlsTask(void *pvParameters) {
     while (isInCorrectState()) {
         shouldUpdateDisplay = false;
 
+        encoderValue = encoder.readEncoder();
+        PlayControls loopControl =  session.playControl;
 #ifdef AJ_DEVELOPMENT_HARDWARE
         next.speedKnob = 0;
 #else
@@ -106,9 +108,8 @@ static void drawPlayControlsTask(void *pvParameters) {
         }
 
         settings.speedKnob = next.speedKnob;
-        encoderValue = encoder.readEncoder();
 
-        switch (session.playControl) {
+        switch (loopControl) {
             case PlayControls::STROKE:
                 next.stroke = encoderValue;
                 shouldUpdateDisplay =
@@ -171,7 +172,7 @@ static void drawPlayControlsTask(void *pvParameters) {
             data.sensation = settings.sensation;
             data.depth = settings.depth;
             data.buffer = settings.buffer;
-            data.activeControl = toUiPlayControl(session.playControl);
+            data.activeControl = toUiPlayControl(loopControl);
             data.strokeCount = session.strokeCount;
             data.distanceMeters = session.distanceMeters;
             data.elapsedMs = displayLastUpdated - session.startTime;


### PR DESCRIPTION
**THIS UNTESTED ON THIS FIRMWARE**

Newest firmware with provenance won't compile for me. Something about "Firmware track", but that's not what this is about... That's just why it is untested. I've implemented a similar fix on the Lite firmware.


The variables that were moved are responsible for determining settings and UI elements on the stroke engine UI. They sometimes were being changed suddenly when switching to the pattern UI.
I believe the culprit is the analog read for 50ms. While the current loop is waiting that 50ms it is possible for the pattern UI to launch and change the encoder values. This would then lead to the play loop reading that new value and setting one of the play settings (like depth) to the value of the pattern selected. In some cases this caused an extreme change in depths.


There might be a better way to fix this, but reading prior to the 50ms delay seems to have stopped the behavior on the lite firmware.
